### PR TITLE
Update program offerings and application copy for new institutions

### DIFF
--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -38,7 +38,7 @@ export default function LandingPage() {
               Your Future Starts Here
             </h1>
             <p className="text-xl md:text-2xl mb-8 max-w-3xl mx-auto">
-              Join MIHAS and KATC - Leading institutions in health sciences and technical education in Zambia
+              Join Mukuba Institute of Health and Applied Sciences and Kalulushi Training Centre – Leading institutions in health sciences education in Zambia
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Link to="/auth/signup">
@@ -115,27 +115,20 @@ export default function LandingPage() {
           <div className="grid md:grid-cols-2 gap-8">
             <div className="bg-white p-6 rounded-lg shadow-md border">
               <h3 className="text-2xl font-bold text-blue-900 mb-4">
-                MIHAS - Health Sciences
+                Kalulushi Training Centre
               </h3>
               <ul className="space-y-2 text-gray-600">
-                <li>• Certificate in Nursing</li>
                 <li>• Diploma in Clinical Medicine</li>
-                <li>• Certificate in Pharmacy Technology</li>
-                <li>• Diploma in Medical Laboratory Technology</li>
-                <li>• Certificate in Community Health</li>
+                <li>• Diploma in Environmental Health</li>
               </ul>
             </div>
-            
+
             <div className="bg-white p-6 rounded-lg shadow-md border">
               <h3 className="text-2xl font-bold text-blue-900 mb-4">
-                KATC - Technical Training
+                Mukuba Institute of Health and Applied Sciences
               </h3>
               <ul className="space-y-2 text-gray-600">
-                <li>• Certificate in Information Technology</li>
-                <li>• Diploma in Electrical Engineering</li>
-                <li>• Certificate in Automotive Technology</li>
-                <li>• Diploma in Business Administration</li>
-                <li>• Certificate in Welding and Fabrication</li>
+                <li>• Diploma in Registered Nursing</li>
               </ul>
             </div>
           </div>

--- a/src/pages/student/ApplicationForm.tsx
+++ b/src/pages/student/ApplicationForm.tsx
@@ -12,6 +12,36 @@ import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 import { ArrowLeft, Upload, X, FileText, CheckCircle } from 'lucide-react'
 import { Link } from 'react-router-dom'
 
+const DEFAULT_PROGRAMS: Program[] = [
+  {
+    id: 'diploma-clinical-medicine',
+    name: 'Diploma in Clinical Medicine',
+    description: '',
+    duration_years: 3,
+    is_active: true,
+    created_at: '',
+    updated_at: ''
+  },
+  {
+    id: 'diploma-environmental-health',
+    name: 'Diploma in Environmental Health',
+    description: '',
+    duration_years: 3,
+    is_active: true,
+    created_at: '',
+    updated_at: ''
+  },
+  {
+    id: 'diploma-registered-nursing',
+    name: 'Diploma in Registered Nursing',
+    description: '',
+    duration_years: 3,
+    is_active: true,
+    created_at: '',
+    updated_at: ''
+  }
+]
+
 const applicationSchema = z.object({
   program_id: z.string().min(1, 'Please select a program'),
   intake_id: z.string().min(1, 'Please select an intake'),
@@ -84,9 +114,15 @@ export default function ApplicationFormPage() {
         .order('name')
 
       if (error) throw error
-      setPrograms(data || [])
+
+      if (data && data.length > 0) {
+        setPrograms(data)
+      } else {
+        setPrograms(DEFAULT_PROGRAMS)
+      }
     } catch (error: any) {
       console.error('Error loading programs:', error)
+      setPrograms(DEFAULT_PROGRAMS)
       setError('Failed to load programs')
     } finally {
       setProgramsLoading(false)
@@ -270,7 +306,7 @@ export default function ApplicationFormPage() {
             Application Form
           </h1>
           <p className="text-gray-600">
-            Complete all sections to submit your application to MIHAS or KATC programs.
+            Complete all sections to submit your application to programs at Kalulushi Training Centre or Mukuba Institute of Health and Applied Sciences.
           </p>
         </div>
 

--- a/src/pages/student/Dashboard.tsx
+++ b/src/pages/student/Dashboard.tsx
@@ -149,7 +149,7 @@ export default function StudentDashboard() {
                   Ready to Apply?
                 </h2>
                 <p className="text-blue-700">
-                  Start your application to join MIHAS or KATC programs
+                  Start your application to join programs at Kalulushi Training Centre or Mukuba Institute of Health and Applied Sciences
                 </p>
               </div>
               <Link to="/apply">


### PR DESCRIPTION
## Summary
- refresh landing page hero and program cards for Kalulushi Training Centre and Mukuba Institute of Health and Applied Sciences
- add fallback program list to application form and update related guidance copy
- update dashboard prompt to reflect new program options

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68c27a4a700483329003dd7e23251196