### PR TITLE
fix: update Button types for framer-motion compatibility

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { motion } from 'framer-motion'
+import { motion, type HTMLMotionProps } from 'framer-motion'
 import { cn } from '@/lib/utils'
 
-interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+interface ButtonProps extends HTMLMotionProps<'button'> {
   variant?: 'primary' | 'secondary' | 'outline' | 'ghost' | 'danger' | 'gradient'
   size?: 'sm' | 'md' | 'lg' | 'xl'
   loading?: boolean


### PR DESCRIPTION
## Summary
- extend ButtonProps from `HTMLMotionProps<'button'>`
- include HTMLMotionProps import to align framer-motion types

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c3ee22dadc83328100cc0ae4bd87c7