### PR TITLE
Refactor applications API to support REST-driven UI

### DIFF
--- a/api/_utils/auth.js
+++ b/api/_utils/auth.js
@@ -1,0 +1,36 @@
+import { supabaseAuthClient, supabaseAdminClient } from './supabaseClient'
+
+const ADMIN_ROLES = new Set(['admin', 'super_admin', 'admissions_officer'])
+
+export async function getAuthenticatedUser(req) {
+  const authHeader = req.headers.authorization
+  if (!authHeader) {
+    return { error: 'No authorization header provided' }
+  }
+
+  const token = authHeader.replace('Bearer ', '').trim()
+  if (!token) {
+    return { error: 'Invalid authorization header' }
+  }
+
+  const { data, error } = await supabaseAuthClient.auth.getUser(token)
+  if (error || !data?.user) {
+    return { error: 'Invalid or expired token' }
+  }
+
+  const user = data.user
+
+  const { data: rolesData, error: rolesError } = await supabaseAdminClient
+    .from('user_roles')
+    .select('role')
+    .eq('user_id', user.id)
+    .eq('is_active', true)
+
+  if (rolesError) {
+    return { error: rolesError.message }
+  }
+
+  const isAdmin = rolesData?.some(role => ADMIN_ROLES.has(role.role)) || false
+
+  return { user, isAdmin }
+}

--- a/api/_utils/supabaseClient.js
+++ b/api/_utils/supabaseClient.js
@@ -1,0 +1,23 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.VITE_SUPABASE_URL
+const supabaseAnonKey = process.env.VITE_SUPABASE_ANON_KEY
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || supabaseAnonKey
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Supabase environment variables are not configured')
+}
+
+export const supabaseAuthClient = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    persistSession: false,
+    autoRefreshToken: false
+  }
+})
+
+export const supabaseAdminClient = createClient(supabaseUrl, supabaseServiceKey, {
+  auth: {
+    persistSession: false,
+    autoRefreshToken: false
+  }
+})

--- a/api/analytics/metrics.js
+++ b/api/analytics/metrics.js
@@ -1,48 +1,44 @@
-import { createClient } from '@supabase/supabase-js'
-
-const supabase = createClient(
-  process.env.VITE_SUPABASE_URL,
-  process.env.VITE_SUPABASE_ANON_KEY
-)
+import { supabaseAdminClient } from '../_utils/supabaseClient'
+import { getAuthenticatedUser } from '../_utils/auth'
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' })
   }
 
-  const authHeader = req.headers.authorization
-  if (!authHeader) {
-    return res.status(401).json({ error: 'No authorization header' })
+  const authContext = await getAuthenticatedUser(req)
+  if (authContext.error) {
+    return res.status(401).json({ error: authContext.error })
   }
 
   try {
-    const { data: totalApps } = await supabase
-      .from('applications')
-      .select('id', { count: 'exact' })
-
-    const { data: submittedApps } = await supabase
-      .from('applications')
-      .select('id', { count: 'exact' })
-      .eq('status', 'submitted')
-
-    const { data: approvedApps } = await supabase
-      .from('applications')
-      .select('id', { count: 'exact' })
-      .eq('status', 'approved')
-
-    const { data: recentApps } = await supabase
-      .from('applications')
-      .select('created_at, status, program')
-      .gte('created_at', new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString())
-      .order('created_at', { ascending: false })
+    const [totalApps, submittedApps, approvedApps, recentApps] = await Promise.all([
+      supabaseAdminClient
+        .from('applications_new')
+        .select('id', { count: 'exact', head: true }),
+      supabaseAdminClient
+        .from('applications_new')
+        .select('id', { count: 'exact', head: true })
+        .eq('status', 'submitted'),
+      supabaseAdminClient
+        .from('applications_new')
+        .select('id', { count: 'exact', head: true })
+        .eq('status', 'approved'),
+      supabaseAdminClient
+        .from('applications_new')
+        .select('created_at, status, program')
+        .gte('created_at', new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString())
+        .order('created_at', { ascending: false })
+    ])
 
     return res.status(200).json({
-      totalApplications: totalApps?.length || 0,
-      submittedApplications: submittedApps?.length || 0,
-      approvedApplications: approvedApps?.length || 0,
-      recentApplications: recentApps || []
+      totalApplications: Number(totalApps.count || 0),
+      submittedApplications: Number(submittedApps.count || 0),
+      approvedApplications: Number(approvedApps.count || 0),
+      recentApplications: recentApps.data || []
     })
   } catch (error) {
+    console.error('Analytics metrics error', error)
     return res.status(500).json({ error: 'Internal server error' })
   }
 }

--- a/api/applications/[id].js
+++ b/api/applications/[id].js
@@ -1,63 +1,253 @@
-import { createClient } from '@supabase/supabase-js'
+import { supabaseAdminClient } from '../_utils/supabaseClient'
+import { getAuthenticatedUser } from '../_utils/auth'
 
-const supabase = createClient(
-  process.env.VITE_SUPABASE_URL,
-  process.env.VITE_SUPABASE_ANON_KEY
-)
+const HISTORY_TABLE = 'application_status_history'
+const DOCUMENTS_TABLE = 'application_documents'
+
+function parseIncludeParam(includeParam) {
+  if (!includeParam) return new Set()
+  if (Array.isArray(includeParam)) {
+    return new Set(includeParam.flatMap(value => value.split(',').map(item => item.trim()).filter(Boolean)))
+  }
+  return new Set(includeParam.split(',').map(item => item.trim()).filter(Boolean))
+}
 
 export default async function handler(req, res) {
-  const { id } = req.query
-  const authHeader = req.headers.authorization
-  
-  if (!authHeader) {
-    return res.status(401).json({ error: 'No authorization header' })
+  const authContext = await getAuthenticatedUser(req)
+  if (authContext.error) {
+    return res.status(401).json({ error: authContext.error })
   }
 
-  const token = authHeader.replace('Bearer ', '')
-  const { data: { user }, error: authError } = await supabase.auth.getUser(token)
-  
-  if (authError || !user) {
-    return res.status(401).json({ error: 'Invalid token' })
+  const { id } = req.query
+  if (!id || Array.isArray(id)) {
+    return res.status(400).json({ error: 'Invalid application id' })
   }
 
   switch (req.method) {
     case 'GET':
-      return getApplication(req, res, user, id)
+      return handleGet(req, res, authContext, id)
     case 'PUT':
-      return updateApplication(req, res, user, id)
+      return handlePut(req, res, authContext, id)
+    case 'PATCH':
+      return handlePatch(req, res, authContext, id)
     case 'DELETE':
-      return deleteApplication(req, res, user, id)
+      return handleDelete(req, res, authContext, id)
     default:
       return res.status(405).json({ error: 'Method not allowed' })
   }
 }
 
-async function getApplication(req, res, user, id) {
+async function handleGet(req, res, { user, isAdmin }, id) {
   try {
-    const { data, error } = await supabase
-      .from('applications')
-      .select('*')
+    const include = parseIncludeParam(req.query.include)
+
+    const selectClauses = ['*']
+    if (include.has('documents')) {
+      selectClauses.push(`documents:${DOCUMENTS_TABLE}(id, document_type, document_name, file_url, file_size, mime_type, verification_status, verified_by, verified_at, verification_notes)`)
+    }
+    if (include.has('grades')) {
+      selectClauses.push('grades:application_grades(subject_id, grade, subject:grade12_subjects(name))')
+    }
+    if (include.has('statusHistory')) {
+      selectClauses.push('status_history:application_status_history(id, status, changed_by, notes, created_at, changed_by_profile:changed_by(email))')
+    }
+
+    const { data, error } = await supabaseAdminClient
+      .from('applications_new')
+      .select(selectClauses.join(','))
       .eq('id', id)
-      .eq('user_id', user.id)
-      .single()
+      .maybeSingle()
 
     if (error) {
+      return res.status(404).json({ error: error.message })
+    }
+
+    if (!data) {
       return res.status(404).json({ error: 'Application not found' })
     }
 
-    return res.status(200).json(data)
+    if (!isAdmin && data.user_id !== user.id) {
+      return res.status(403).json({ error: 'Access denied' })
+    }
+
+    const {
+      documents: rawDocuments = [],
+      grades: rawGrades = [],
+      status_history: rawHistory = [],
+      ...application
+    } = data
+
+    let documents = undefined
+    if (include.has('documents')) {
+      documents = [...rawDocuments]
+
+      const existingTypes = new Set(documents.map(doc => doc.document_type))
+      if (application.result_slip_url && !existingTypes.has('result_slip')) {
+        documents.push({
+          id: 'result_slip',
+          document_type: 'result_slip',
+          document_name: 'Grade 12 Result Slip',
+          file_url: application.result_slip_url,
+          verification_status: 'pending'
+        })
+      }
+      if (application.extra_kyc_url && !existingTypes.has('extra_kyc')) {
+        documents.push({
+          id: 'extra_kyc',
+          document_type: 'extra_kyc',
+          document_name: 'Additional KYC Document',
+          file_url: application.extra_kyc_url,
+          verification_status: 'pending'
+        })
+      }
+      if (application.pop_url && !existingTypes.has('proof_of_payment')) {
+        documents.push({
+          id: 'proof_of_payment',
+          document_type: 'proof_of_payment',
+          document_name: 'Proof of Payment',
+          file_url: application.pop_url,
+          verification_status: 'pending'
+        })
+      }
+    }
+
+    const grades = include.has('grades')
+      ? rawGrades.map(grade => ({
+          subject_id: grade.subject_id,
+          grade: grade.grade,
+          subject_name: grade.subject?.name || null
+        }))
+      : undefined
+
+    const statusHistory = include.has('statusHistory') ? rawHistory : undefined
+
+    return res.status(200).json({
+      application,
+      documents,
+      grades,
+      statusHistory
+    })
   } catch (error) {
+    console.error('Application GET error', error)
     return res.status(500).json({ error: 'Internal server error' })
   }
 }
 
-async function updateApplication(req, res, user, id) {
+async function handlePut(req, res, { user, isAdmin }, id) {
   try {
-    const { data, error } = await supabase
-      .from('applications')
-      .update(req.body)
+    const updates = req.body || {}
+
+    let query = supabaseAdminClient
+      .from('applications_new')
+      .update(updates)
       .eq('id', id)
-      .eq('user_id', user.id)
+
+    if (!isAdmin) {
+      query = query.eq('user_id', user.id)
+    }
+
+    const { data, error } = await query.select().single()
+
+    if (error) {
+      return res.status(400).json({ error: error.message })
+    }
+
+    return res.status(200).json(data)
+  } catch (error) {
+    console.error('Application UPDATE error', error)
+    return res.status(500).json({ error: 'Internal server error' })
+  }
+}
+
+async function handlePatch(req, res, context, id) {
+  const { action } = req.body || {}
+  if (!action) {
+    return res.status(400).json({ error: 'Action is required' })
+  }
+
+  switch (action) {
+    case 'verify_document':
+      return verifyDocument(req, res, context, id)
+    case 'update_status':
+      return updateApplicationStatus(req, res, context, id)
+    case 'update_payment_status':
+      return updatePaymentStatus(req, res, context, id)
+    case 'send_notification':
+      return sendNotification(req, res, context, id)
+    case 'sync_grades':
+      return syncGrades(req, res, context, id)
+    default:
+      return res.status(400).json({ error: 'Unsupported action' })
+  }
+}
+
+async function handleDelete(req, res, { user, isAdmin }, id) {
+  try {
+    let query = supabaseAdminClient
+      .from('applications_new')
+      .update({ status: 'deleted', updated_at: new Date().toISOString() })
+      .eq('id', id)
+
+    if (!isAdmin) {
+      query = query.eq('user_id', user.id)
+    }
+
+    const { error } = await query
+    if (error) {
+      return res.status(400).json({ error: error.message })
+    }
+
+    return res.status(200).json({ success: true })
+  } catch (error) {
+    console.error('Application DELETE error', error)
+    return res.status(500).json({ error: 'Internal server error' })
+  }
+}
+
+async function verifyDocument(req, res, { user, isAdmin }, id) {
+  if (!isAdmin) {
+    return res.status(403).json({ error: 'Access denied' })
+  }
+
+  const { documentId, documentType, status, notes } = req.body || {}
+  if (!documentId && !documentType) {
+    return res.status(400).json({ error: 'Document identifier is required' })
+  }
+  if (!status) {
+    return res.status(400).json({ error: 'Status is required' })
+  }
+
+  try {
+    let targetId = documentId
+
+    if (!targetId) {
+      const { data: existing, error: lookupError } = await supabaseAdminClient
+        .from(DOCUMENTS_TABLE)
+        .select('id')
+        .eq('application_id', id)
+        .eq('document_type', documentType)
+        .maybeSingle()
+
+      if (lookupError) {
+        return res.status(400).json({ error: lookupError.message })
+      }
+
+      targetId = existing?.id
+      if (!targetId) {
+        return res.status(404).json({ error: 'Document not found' })
+      }
+    }
+
+    const { data, error } = await supabaseAdminClient
+      .from(DOCUMENTS_TABLE)
+      .update({
+        verification_status: status,
+        verified_by: user.id,
+        verified_at: new Date().toISOString(),
+        verification_notes: notes || null
+      })
+      .eq('id', targetId)
+      .eq('application_id', id)
       .select()
       .single()
 
@@ -67,24 +257,198 @@ async function updateApplication(req, res, user, id) {
 
     return res.status(200).json(data)
   } catch (error) {
+    console.error('Document verification error', error)
     return res.status(500).json({ error: 'Internal server error' })
   }
 }
 
-async function deleteApplication(req, res, user, id) {
+async function updateApplicationStatus(req, res, { user, isAdmin }, id) {
+  if (!isAdmin) {
+    return res.status(403).json({ error: 'Access denied' })
+  }
+
+  const { status, notes } = req.body || {}
+  if (!status) {
+    return res.status(400).json({ error: 'Status is required' })
+  }
+
   try {
-    const { error } = await supabase
-      .from('applications')
-      .delete()
+    const updateData = {
+      status,
+      updated_at: new Date().toISOString()
+    }
+
+    if (status === 'under_review') {
+      updateData.review_started_at = new Date().toISOString()
+    }
+
+    if (['approved', 'rejected'].includes(status)) {
+      updateData.decision_date = new Date().toISOString()
+    }
+
+    const { data, error } = await supabaseAdminClient
+      .from('applications_new')
+      .update(updateData)
       .eq('id', id)
-      .eq('user_id', user.id)
+      .select()
+      .single()
 
     if (error) {
       return res.status(400).json({ error: error.message })
     }
 
-    return res.status(204).end()
+    await supabaseAdminClient
+      .from(HISTORY_TABLE)
+      .insert({
+        application_id: id,
+        status,
+        changed_by: user.id,
+        notes: notes || null
+      })
+
+    return res.status(200).json(data)
   } catch (error) {
+    console.error('Status update error', error)
+    return res.status(500).json({ error: 'Internal server error' })
+  }
+}
+
+async function updatePaymentStatus(req, res, { isAdmin }, id) {
+  if (!isAdmin) {
+    return res.status(403).json({ error: 'Access denied' })
+  }
+
+  const { paymentStatus } = req.body || {}
+  if (!paymentStatus) {
+    return res.status(400).json({ error: 'Payment status is required' })
+  }
+
+  try {
+    const { data, error } = await supabaseAdminClient
+      .from('applications_new')
+      .update({
+        payment_status: paymentStatus,
+        updated_at: new Date().toISOString()
+      })
+      .eq('id', id)
+      .select()
+      .single()
+
+    if (error) {
+      return res.status(400).json({ error: error.message })
+    }
+
+    return res.status(200).json(data)
+  } catch (error) {
+    console.error('Payment status update error', error)
+    return res.status(500).json({ error: 'Internal server error' })
+  }
+}
+
+async function sendNotification(req, res, { user, isAdmin }, id) {
+  if (!isAdmin) {
+    return res.status(403).json({ error: 'Access denied' })
+  }
+
+  const { title, message } = req.body || {}
+  if (!title || !message) {
+    return res.status(400).json({ error: 'Title and message are required' })
+  }
+
+  try {
+    const { data: application, error: fetchError } = await supabaseAdminClient
+      .from('applications_new')
+      .select('user_id')
+      .eq('id', id)
+      .maybeSingle()
+
+    if (fetchError) {
+      return res.status(400).json({ error: fetchError.message })
+    }
+
+    if (!application) {
+      return res.status(404).json({ error: 'Application not found' })
+    }
+
+    await supabaseAdminClient
+      .from('notifications')
+      .insert({
+        user_id: application.user_id,
+        title,
+        message,
+        type: 'application_update'
+      })
+
+    await supabaseAdminClient
+      .from('applications_new')
+      .update({
+        admin_feedback: message,
+        admin_feedback_date: new Date().toISOString(),
+        admin_feedback_by: user.id,
+        updated_at: new Date().toISOString()
+      })
+      .eq('id', id)
+
+    return res.status(200).json({ success: true })
+  } catch (error) {
+    console.error('Notification error', error)
+    return res.status(500).json({ error: 'Internal server error' })
+  }
+}
+
+async function syncGrades(req, res, { user, isAdmin }, id) {
+  const { grades } = req.body || {}
+  if (!Array.isArray(grades)) {
+    return res.status(400).json({ error: 'Grades must be an array' })
+  }
+
+  try {
+    // Ensure application belongs to the user unless admin
+    if (!isAdmin) {
+      const { data: application, error } = await supabaseAdminClient
+        .from('applications_new')
+        .select('id, user_id')
+        .eq('id', id)
+        .maybeSingle()
+
+      if (error) {
+        return res.status(400).json({ error: error.message })
+      }
+
+      if (!application || application.user_id !== user.id) {
+        return res.status(403).json({ error: 'Access denied' })
+      }
+    }
+
+    // Remove existing grades for the application
+    await supabaseAdminClient
+      .from('application_grades')
+      .delete()
+      .eq('application_id', id)
+
+    if (grades.length > 0) {
+      const gradeRows = grades
+        .filter(grade => grade.subject_id)
+        .map(grade => ({
+          application_id: id,
+          subject_id: grade.subject_id,
+          grade: grade.grade
+        }))
+
+      if (gradeRows.length > 0) {
+        const { error: insertError } = await supabaseAdminClient
+          .from('application_grades')
+          .insert(gradeRows)
+
+        if (insertError) {
+          return res.status(400).json({ error: insertError.message })
+        }
+      }
+    }
+
+    return res.status(200).json({ success: true })
+  } catch (error) {
+    console.error('Sync grades error', error)
     return res.status(500).json({ error: 'Internal server error' })
   }
 }

--- a/api/applications/bulk.js
+++ b/api/applications/bulk.js
@@ -1,0 +1,145 @@
+import { supabaseAdminClient } from '../_utils/supabaseClient'
+import { getAuthenticatedUser } from '../_utils/auth'
+
+export default async function handler(req, res) {
+  const authContext = await getAuthenticatedUser(req)
+  if (authContext.error) {
+    return res.status(401).json({ error: authContext.error })
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  if (!authContext.isAdmin) {
+    return res.status(403).json({ error: 'Access denied' })
+  }
+
+  const { action, applicationIds = [], status, paymentStatus, notification } = req.body || {}
+
+  if (!action) {
+    return res.status(400).json({ error: 'Action is required' })
+  }
+
+  if (!Array.isArray(applicationIds) || applicationIds.length === 0) {
+    return res.status(400).json({ error: 'applicationIds must be a non-empty array' })
+  }
+
+  try {
+    switch (action) {
+      case 'update_status':
+        return bulkUpdateStatus(res, authContext.user.id, applicationIds, status)
+      case 'update_payment_status':
+        return bulkUpdatePaymentStatus(res, applicationIds, paymentStatus)
+      case 'delete':
+        return bulkDeleteApplications(res, applicationIds)
+      case 'send_notifications':
+        return bulkSendNotifications(res, applicationIds, notification)
+      default:
+        return res.status(400).json({ error: 'Unsupported action' })
+    }
+  } catch (error) {
+    console.error('Bulk action error', error)
+    return res.status(500).json({ error: 'Internal server error' })
+  }
+}
+
+async function bulkUpdateStatus(res, userId, applicationIds, status) {
+  if (!status) {
+    return res.status(400).json({ error: 'Status is required' })
+  }
+
+  const now = new Date().toISOString()
+  const updateData = { status, updated_at: now }
+  if (status === 'under_review') {
+    updateData.review_started_at = now
+  }
+  if (['approved', 'rejected'].includes(status)) {
+    updateData.decision_date = now
+  }
+
+  const { error } = await supabaseAdminClient
+    .from('applications_new')
+    .update(updateData)
+    .in('id', applicationIds)
+
+  if (error) {
+    return res.status(400).json({ error: error.message })
+  }
+
+  const historyRows = applicationIds.map(id => ({
+    application_id: id,
+    status,
+    changed_by: userId
+  }))
+
+  await supabaseAdminClient
+    .from('application_status_history')
+    .insert(historyRows)
+
+  return res.status(200).json({ successCount: applicationIds.length })
+}
+
+async function bulkUpdatePaymentStatus(res, applicationIds, paymentStatus) {
+  if (!paymentStatus) {
+    return res.status(400).json({ error: 'paymentStatus is required' })
+  }
+
+  const { error } = await supabaseAdminClient
+    .from('applications_new')
+    .update({ payment_status: paymentStatus, updated_at: new Date().toISOString() })
+    .in('id', applicationIds)
+
+  if (error) {
+    return res.status(400).json({ error: error.message })
+  }
+
+  return res.status(200).json({ successCount: applicationIds.length })
+}
+
+async function bulkDeleteApplications(res, applicationIds) {
+  const { error } = await supabaseAdminClient
+    .from('applications_new')
+    .update({ status: 'deleted', updated_at: new Date().toISOString() })
+    .in('id', applicationIds)
+
+  if (error) {
+    return res.status(400).json({ error: error.message })
+  }
+
+  return res.status(200).json({ successCount: applicationIds.length })
+}
+
+async function bulkSendNotifications(res, applicationIds, notification) {
+  if (!notification?.title || !notification?.message) {
+    return res.status(400).json({ error: 'Notification title and message are required' })
+  }
+
+  const { data: applications, error: fetchError } = await supabaseAdminClient
+    .from('applications_new')
+    .select('id, user_id, full_name, email, application_number')
+    .in('id', applicationIds)
+
+  if (fetchError) {
+    return res.status(400).json({ error: fetchError.message })
+  }
+
+  const notifications = applications.map(app => ({
+    user_id: app.user_id,
+    title: notification.title.replace('{application_number}', app.application_number),
+    message: notification.message
+      .replace('{full_name}', app.full_name)
+      .replace('{application_number}', app.application_number),
+    type: 'application_update'
+  }))
+
+  const { error } = await supabaseAdminClient
+    .from('notifications')
+    .insert(notifications)
+
+  if (error) {
+    return res.status(400).json({ error: error.message })
+  }
+
+  return res.status(200).json({ successCount: notifications.length })
+}

--- a/api/applications/index.js
+++ b/api/applications/index.js
@@ -1,61 +1,206 @@
-import { createClient } from '@supabase/supabase-js'
+import { supabaseAdminClient } from '../_utils/supabaseClient'
+import { getAuthenticatedUser } from '../_utils/auth'
 
-const supabase = createClient(
-  process.env.VITE_SUPABASE_URL,
-  process.env.VITE_SUPABASE_ANON_KEY
-)
+const DEFAULT_PAGE_SIZE = 15
+const ALLOWED_SORT_FIELDS = new Set(['date', 'name', 'status'])
+const SORT_FIELD_MAP = {
+  date: 'created_at',
+  name: 'full_name',
+  status: 'status'
+}
+
+function sanitizeSearchTerm(term = '') {
+  return term.replace(/[%_\\]/g, '\\$&').replace(/'/g, "''")
+}
+
+function parseBoolean(value) {
+  if (typeof value === 'string') {
+    return value.toLowerCase() === 'true'
+  }
+  return Boolean(value)
+}
 
 export default async function handler(req, res) {
-  const authHeader = req.headers.authorization
-  if (!authHeader) {
-    return res.status(401).json({ error: 'No authorization header' })
-  }
-
-  const token = authHeader.replace('Bearer ', '')
-  const { data: { user }, error: authError } = await supabase.auth.getUser(token)
-  
-  if (authError || !user) {
-    return res.status(401).json({ error: 'Invalid token' })
+  const authContext = await getAuthenticatedUser(req)
+  if (authContext.error) {
+    return res.status(401).json({ error: authContext.error })
   }
 
   switch (req.method) {
     case 'GET':
-      return getApplications(req, res, user)
+      return handleGet(req, res, authContext)
     case 'POST':
-      return createApplication(req, res, user)
+      return handlePost(req, res, authContext)
     default:
       return res.status(405).json({ error: 'Method not allowed' })
   }
 }
 
-async function getApplications(req, res, user) {
+async function handleGet(req, res, { user, isAdmin }) {
   try {
-    const { data, error } = await supabase
-      .from('applications')
-      .select('*')
-      .eq('user_id', user.id)
-      .order('created_at', { ascending: false })
+    const {
+      page = '0',
+      pageSize = DEFAULT_PAGE_SIZE.toString(),
+      status = 'all',
+      search = '',
+      sortBy = 'date',
+      sortOrder = 'desc',
+      program = 'all',
+      institution = 'all',
+      paymentStatus = 'all',
+      startDate = '',
+      endDate = '',
+      includeStats = 'false',
+      mine = 'false'
+    } = req.query
+
+    const parsedPage = Math.max(parseInt(Array.isArray(page) ? page[0] : page, 10) || 0, 0)
+    const parsedPageSizeValue = Array.isArray(pageSize) ? pageSize[0] : pageSize
+    const parsedPageSize = parsedPageSizeValue === 'all'
+      ? 'all'
+      : Math.min(Math.max(parseInt(parsedPageSizeValue, 10) || DEFAULT_PAGE_SIZE, 1), 200)
+
+    const shouldIncludeStats = parseBoolean(Array.isArray(includeStats) ? includeStats[0] : includeStats)
+    const limitToUser = !isAdmin || parseBoolean(Array.isArray(mine) ? mine[0] : mine)
+
+    const sortFieldKey = Array.isArray(sortBy) ? sortBy[0] : sortBy
+    const orderField = ALLOWED_SORT_FIELDS.has(sortFieldKey) ? SORT_FIELD_MAP[sortFieldKey] : SORT_FIELD_MAP.date
+    const orderAscending = (Array.isArray(sortOrder) ? sortOrder[0] : sortOrder) === 'asc'
+
+    const statusFilter = Array.isArray(status) ? status[0] : status
+    const programFilter = Array.isArray(program) ? program[0] : program
+    const institutionFilter = Array.isArray(institution) ? institution[0] : institution
+    const paymentStatusFilter = Array.isArray(paymentStatus) ? paymentStatus[0] : paymentStatus
+    const searchTerm = Array.isArray(search) ? search[0] : search
+    const startDateFilter = Array.isArray(startDate) ? startDate[0] : startDate
+    const endDateFilter = Array.isArray(endDate) ? endDate[0] : endDate
+
+    let query = supabaseAdminClient
+      .from('applications_new')
+      .select('*', { count: 'exact' })
+
+    if (limitToUser) {
+      query = query.eq('user_id', user.id)
+    }
+
+    if (statusFilter && statusFilter !== 'all') {
+      query = query.eq('status', statusFilter)
+    } else {
+      query = query.in('status', ['draft', 'submitted', 'under_review', 'approved', 'rejected'])
+    }
+
+    if (programFilter && programFilter !== 'all') {
+      query = query.eq('program', programFilter)
+    }
+
+    if (institutionFilter && institutionFilter !== 'all') {
+      query = query.eq('institution', institutionFilter)
+    }
+
+    if (paymentStatusFilter && paymentStatusFilter !== 'all') {
+      query = query.eq('payment_status', paymentStatusFilter)
+    }
+
+    if (startDateFilter) {
+      query = query.gte('created_at', startDateFilter)
+    }
+
+    if (endDateFilter) {
+      query = query.lte('created_at', `${endDateFilter}T23:59:59`)
+    }
+
+    if (searchTerm) {
+      const sanitizedSearch = sanitizeSearchTerm(searchTerm)
+      query = query.or(
+        [
+          `full_name.ilike.%${sanitizedSearch}%`,
+          `email.ilike.%${sanitizedSearch}%`,
+          `application_number.ilike.%${sanitizedSearch}%`,
+          `phone.ilike.%${sanitizedSearch}%`,
+          `nrc_number.ilike.%${sanitizedSearch}%`
+        ].join(',')
+      )
+    }
+
+    query = query.order(orderField, { ascending: orderAscending })
+
+    if (parsedPageSize !== 'all') {
+      const rangeStart = parsedPage * parsedPageSize
+      const rangeEnd = rangeStart + parsedPageSize - 1
+      query = query.range(rangeStart, rangeEnd)
+    }
+
+    const { data, error, count } = await query
 
     if (error) {
       return res.status(400).json({ error: error.message })
     }
 
-    return res.status(200).json(data)
+    let stats = null
+    if (shouldIncludeStats) {
+      stats = await fetchApplicationStats(limitToUser ? user.id : null)
+    }
+
+    return res.status(200).json({
+      applications: data || [],
+      totalCount: count || 0,
+      stats
+    })
   } catch (error) {
+    console.error('Applications GET error', error)
     return res.status(500).json({ error: 'Internal server error' })
   }
 }
 
-async function createApplication(req, res, user) {
+async function fetchApplicationStats(userId) {
   try {
-    const applicationData = {
-      ...req.body,
-      user_id: user.id,
-      status: 'draft'
+    let baseQuery = supabaseAdminClient
+      .from('applications_new')
+      .select('status, payment_status')
+
+    if (userId) {
+      baseQuery = baseQuery.eq('user_id', userId)
     }
 
-    const { data, error } = await supabase
-      .from('applications')
+    const { data, error } = await baseQuery
+    if (error) {
+      throw error
+    }
+
+    const stats = {
+      total: data.length,
+      draft: 0,
+      submitted: 0,
+      under_review: 0,
+      approved: 0,
+      rejected: 0
+    }
+
+    data.forEach(app => {
+      if (stats.hasOwnProperty(app.status)) {
+        stats[app.status] += 1
+      }
+    })
+
+    return stats
+  } catch (error) {
+    console.error('Failed to fetch application stats', error)
+    return null
+  }
+}
+
+async function handlePost(req, res, { user }) {
+  try {
+    const payload = req.body || {}
+
+    const applicationData = {
+      ...payload,
+      user_id: user.id,
+      status: payload.status || 'draft'
+    }
+
+    const { data, error } = await supabaseAdminClient
+      .from('applications_new')
       .insert(applicationData)
       .select()
       .single()
@@ -66,6 +211,7 @@ async function createApplication(req, res, user) {
 
     return res.status(201).json(data)
   } catch (error) {
+    console.error('Applications POST error', error)
     return res.status(500).json({ error: 'Internal server error' })
   }
 }

--- a/api/catalog/grade12-subjects.js
+++ b/api/catalog/grade12-subjects.js
@@ -1,0 +1,30 @@
+import { supabaseAdminClient } from '../_utils/supabaseClient'
+import { getAuthenticatedUser } from '../_utils/auth'
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const authContext = await getAuthenticatedUser(req)
+  if (authContext.error) {
+    return res.status(401).json({ error: authContext.error })
+  }
+
+  try {
+    const { data, error } = await supabaseAdminClient
+      .from('grade12_subjects')
+      .select('*')
+      .eq('is_active', true)
+      .order('name')
+
+    if (error) {
+      return res.status(400).json({ error: error.message })
+    }
+
+    return res.status(200).json({ subjects: data || [] })
+  } catch (error) {
+    console.error('Subjects fetch error', error)
+    return res.status(500).json({ error: 'Internal server error' })
+  }
+}

--- a/api/catalog/intakes.js
+++ b/api/catalog/intakes.js
@@ -1,0 +1,30 @@
+import { supabaseAdminClient } from '../_utils/supabaseClient'
+import { getAuthenticatedUser } from '../_utils/auth'
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const authContext = await getAuthenticatedUser(req)
+  if (authContext.error) {
+    return res.status(401).json({ error: authContext.error })
+  }
+
+  try {
+    const { data, error } = await supabaseAdminClient
+      .from('intakes')
+      .select('*')
+      .eq('is_active', true)
+      .order('application_deadline')
+
+    if (error) {
+      return res.status(400).json({ error: error.message })
+    }
+
+    return res.status(200).json({ intakes: data || [] })
+  } catch (error) {
+    console.error('Intakes fetch error', error)
+    return res.status(500).json({ error: 'Internal server error' })
+  }
+}

--- a/api/catalog/programs.js
+++ b/api/catalog/programs.js
@@ -1,0 +1,30 @@
+import { supabaseAdminClient } from '../_utils/supabaseClient'
+import { getAuthenticatedUser } from '../_utils/auth'
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const authContext = await getAuthenticatedUser(req)
+  if (authContext.error) {
+    return res.status(401).json({ error: authContext.error })
+  }
+
+  try {
+    const { data, error } = await supabaseAdminClient
+      .from('programs')
+      .select('*')
+      .eq('is_active', true)
+      .order('name')
+
+    if (error) {
+      return res.status(400).json({ error: error.message })
+    }
+
+    return res.status(200).json({ programs: data || [] })
+  } catch (error) {
+    console.error('Programs fetch error', error)
+    return res.status(500).json({ error: 'Internal server error' })
+  }
+}

--- a/src/hooks/useApplicationsData.ts
+++ b/src/hooks/useApplicationsData.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
-import { supabase } from '@/lib/supabase'
 import { sanitizeForLog } from '@/lib/sanitize'
+import { applicationService } from '@/services/apiClient'
 
 const PAGE_SIZE = 15
 
@@ -42,125 +42,30 @@ export function useApplicationsData(params: ApplicationsDataParams | { currentPa
     dateRange = { start: '', end: '' }
   } = normalizedParams
 
-  const fetchApplications = async () => {
-    try {
-      const start = currentPage * PAGE_SIZE
-      const end = start + PAGE_SIZE - 1
-      
-      let query = supabase
-        .from('applications_new')
-        .select('*', { count: 'exact' })
-        .range(start, end)
-
-      // Apply sorting
-      const orderColumn = sortBy === 'date' ? 'created_at' : 
-                         sortBy === 'name' ? 'full_name' : 'status'
-      query = query.order(orderColumn, { ascending: sortOrder === 'asc' })
-
-      // Apply status filter
-      if (statusFilter !== 'all') {
-        query = query.eq('status', statusFilter)
-      } else {
-        query = query.in('status', ['draft', 'submitted', 'under_review', 'approved', 'rejected'])
-      }
-
-      // Apply program filter
-      if (programFilter !== 'all') {
-        query = query.eq('program', programFilter)
-      }
-
-      // Apply institution filter
-      if (institutionFilter !== 'all') {
-        query = query.eq('institution', institutionFilter)
-      }
-
-      // Apply payment status filter
-      if (paymentStatusFilter !== 'all') {
-        query = query.eq('payment_status', paymentStatusFilter)
-      }
-
-      // Apply date range filter
-      if (dateRange.start) {
-        query = query.gte('created_at', dateRange.start)
-      }
-      if (dateRange.end) {
-        query = query.lte('created_at', dateRange.end + 'T23:59:59')
-      }
-
-      // Apply search filter
-      if (searchTerm) {
-        const sanitizedSearch = searchTerm.replace(/[%_\\]/g, '\\$&').replace(/'/g, "''")
-        query = query.or(`full_name.ilike.%${sanitizedSearch}%,email.ilike.%${sanitizedSearch}%,application_number.ilike.%${sanitizedSearch}%,phone.ilike.%${sanitizedSearch}%,nrc_number.ilike.%${sanitizedSearch}%`)
-      }
-
-      const { data, error, count } = await query
-      
-      if (error) {
-        console.error('Error fetching applications:', sanitizeForLog(error.message))
-        throw new Error(`Failed to fetch applications: ${error.message}`)
-      }
-
-      return { 
-        applications: data || [], 
-        totalCount: count || 0 
-      }
-    } catch (error) {
-      console.error('Applications fetch error:', error)
-      throw error
-    }
-  }
-
-  const fetchStats = async () => {
-    try {
-      const { data, error } = await supabase.rpc('get_admin_dashboard_stats')
-      
-      if (error) {
-        console.error('Error fetching stats:', sanitizeForLog(error.message))
-        // Return default stats if RPC fails
-        const { data: fallbackData, error: fallbackError } = await supabase
-          .from('applications_new')
-          .select('status, payment_status')
-        
-        if (fallbackError) throw fallbackError
-        
-        const stats = {
-          total: fallbackData.length,
-          draft: fallbackData.filter(app => app.status === 'draft').length,
-          submitted: fallbackData.filter(app => app.status === 'submitted').length,
-          under_review: fallbackData.filter(app => app.status === 'under_review').length,
-          approved: fallbackData.filter(app => app.status === 'approved').length,
-          rejected: fallbackData.filter(app => app.status === 'rejected').length
-        }
-        
-        return stats
-      }
-      
-      return {
-        total: Number(data[0]?.total_applications || 0),
-        draft: Number(data[0]?.draft_applications || 0),
-        submitted: Number(data[0]?.submitted_applications || 0),
-        under_review: Number(data[0]?.under_review_applications || 0),
-        approved: Number(data[0]?.approved_applications || 0),
-        rejected: Number(data[0]?.rejected_applications || 0)
-      }
-    } catch (error) {
-      console.error('Stats fetch error:', error)
-      throw error
-    }
-  }
-
   const applicationsQuery = useQuery({
     queryKey: ['applications', currentPage, statusFilter, searchTerm, sortBy, sortOrder, programFilter, institutionFilter, paymentStatusFilter, dateRange],
-    queryFn: fetchApplications,
+    queryFn: async () => {
+      try {
+        return await applicationService.list({
+          page: currentPage,
+          pageSize: PAGE_SIZE,
+          status: statusFilter,
+          search: searchTerm,
+          sortBy,
+          sortOrder,
+          program: programFilter,
+          institution: institutionFilter,
+          paymentStatus: paymentStatusFilter,
+          startDate: dateRange.start,
+          endDate: dateRange.end,
+          includeStats: true
+        })
+      } catch (error: any) {
+        console.error('Applications fetch error:', sanitizeForLog(error?.message || error))
+        throw error
+      }
+    },
     staleTime: 30000,
-    retry: 2,
-    retryDelay: 1000
-  })
-
-  const statsQuery = useQuery({
-    queryKey: ['application-stats'],
-    queryFn: fetchStats,
-    staleTime: 60000,
     retry: 2,
     retryDelay: 1000
   })
@@ -168,11 +73,11 @@ export function useApplicationsData(params: ApplicationsDataParams | { currentPa
   return {
     applications: applicationsQuery.data?.applications || [],
     totalCount: applicationsQuery.data?.totalCount || 0,
-    stats: statsQuery.data,
+    stats: applicationsQuery.data?.stats,
     isLoading: applicationsQuery.isLoading,
-    isStatsLoading: statsQuery.isLoading,
-    error: applicationsQuery.error || statsQuery.error,
+    isStatsLoading: applicationsQuery.isLoading,
+    error: applicationsQuery.error,
     refetch: applicationsQuery.refetch,
-    refetchStats: statsQuery.refetch
+    refetchStats: applicationsQuery.refetch
   }
 }

--- a/src/hooks/useBulkOperations.ts
+++ b/src/hooks/useBulkOperations.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react'
-import { supabase } from '@/lib/supabase'
 import { sanitizeForLog } from '@/lib/sanitize'
+import { apiClient } from '@/services/apiClient'
 
 export function useBulkOperations() {
   const [loading, setLoading] = useState(false)
@@ -11,18 +11,16 @@ export function useBulkOperations() {
       setLoading(true)
       setError('')
       
-      // Use the RPC function for bulk updates
-      const { data, error } = await supabase.rpc('rpc_bulk_update_status', {
-        p_application_ids: applicationIds,
-        p_status: newStatus
+      const response = await apiClient.request('/api/applications/bulk', {
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'update_status',
+          applicationIds,
+          status: newStatus
+        })
       })
 
-      if (error) {
-        console.error('Bulk status update error:', sanitizeForLog(error.message))
-        throw new Error(`Failed to update applications: ${error.message}`)
-      }
-
-      return data || applicationIds.length
+      return response?.successCount || applicationIds.length
     } catch (err: any) {
       const errorMessage = err.message || 'Failed to update application status'
       console.error('Bulk operation error:', sanitizeForLog(errorMessage))
@@ -38,18 +36,16 @@ export function useBulkOperations() {
       setLoading(true)
       setError('')
       
-      // Use the RPC function for bulk payment updates
-      const { data, error } = await supabase.rpc('rpc_bulk_update_payment_status', {
-        p_application_ids: applicationIds,
-        p_payment_status: newPaymentStatus
+      const response = await apiClient.request('/api/applications/bulk', {
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'update_payment_status',
+          applicationIds,
+          paymentStatus: newPaymentStatus
+        })
       })
 
-      if (error) {
-        console.error('Bulk payment status update error:', sanitizeForLog(error.message))
-        throw new Error(`Failed to update payment status: ${error.message}`)
-      }
-
-      return data || applicationIds.length
+      return response?.successCount || applicationIds.length
     } catch (err: any) {
       const errorMessage = err.message || 'Failed to update payment status'
       console.error('Bulk payment operation error:', sanitizeForLog(errorMessage))
@@ -65,41 +61,19 @@ export function useBulkOperations() {
       setLoading(true)
       setError('')
       
-      // Soft delete by updating status to 'deleted'
-      const updates = applicationIds.map(id => 
-        supabase
-          .from('applications_new')
-          .update({
-            status: 'deleted',
-            updated_at: new Date().toISOString()
-          })
-          .eq('id', id)
-      )
-      
-      const results = await Promise.allSettled(updates)
-      
-      let successCount = 0
-      let errorCount = 0
-      const errors: string[] = []
-      
-      results.forEach((result, index) => {
-        if (result.status === 'fulfilled' && !result.value.error) {
-          successCount++
-        } else {
-          errorCount++
-          const errorMsg = result.status === 'rejected' 
-            ? result.reason?.message || 'Unknown error'
-            : result.value.error?.message || 'Update failed'
-          errors.push(`Application ${applicationIds[index]}: ${errorMsg}`)
-        }
+      const response = await apiClient.request('/api/applications/bulk', {
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'delete',
+          applicationIds
+        })
       })
-      
-      if (errorCount > 0) {
-        console.error('Bulk delete errors:', errors)
-        setError(`${errorCount} applications failed to delete: ${errors.join(', ')}`)
+
+      return {
+        successCount: response?.successCount || applicationIds.length,
+        errorCount: 0,
+        errors: []
       }
-      
-      return { successCount, errorCount, errors }
     } catch (err: any) {
       const errorMessage = err.message || 'Failed to delete applications'
       console.error('Bulk delete error:', sanitizeForLog(errorMessage))
@@ -115,33 +89,16 @@ export function useBulkOperations() {
       setLoading(true)
       setError('')
       
-      // Get applications with user info
-      const { data: applications, error: fetchError } = await supabase
-        .from('applications_new')
-        .select('id, user_id, full_name, email, application_number')
-        .in('id', applicationIds)
-      
-      if (fetchError) {
-        throw new Error(`Failed to fetch applications: ${fetchError.message}`)
-      }
-      
-      // Create notifications for each user
-      const notifications = applications.map(app => ({
-        user_id: app.user_id,
-        title: notification.title.replace('{application_number}', app.application_number),
-        message: notification.message.replace('{full_name}', app.full_name).replace('{application_number}', app.application_number),
-        type: 'application_update'
-      }))
-      
-      const { data, error } = await supabase
-        .from('notifications')
-        .insert(notifications)
-      
-      if (error) {
-        throw new Error(`Failed to send notifications: ${error.message}`)
-      }
-      
-      return notifications.length
+      const response = await apiClient.request('/api/applications/bulk', {
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'send_notifications',
+          applicationIds,
+          notification
+        })
+      })
+
+      return response?.successCount || applicationIds.length
     } catch (err: any) {
       const errorMessage = err.message || 'Failed to send notifications'
       console.error('Bulk notification error:', sanitizeForLog(errorMessage))

--- a/src/pages/student/ApplicationStatus.tsx
+++ b/src/pages/student/ApplicationStatus.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import { useParams, Link, useNavigate } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
-import { supabase, ApplicationWithDetails, Program, Intake } from '@/lib/supabase'
+import type { ApplicationWithDetails } from '@/lib/supabase'
 import { Button } from '@/components/ui/Button'
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 import { formatDate, getStatusColor } from '@/lib/utils'
 import { motion } from 'framer-motion'
+import { applicationService } from '@/services/apiClient'
 import { 
   ArrowLeft, 
   FileText, 
@@ -39,21 +40,13 @@ export default function ApplicationStatus() {
     try {
       setLoading(true)
       
-      // Load application with program and intake details
-      const { data: applicationData, error: applicationError } = await supabase
-        .from('applications_new')
-        .select(`
-          *
-        `)
-        .eq('id', id)
-        .eq('user_id', user?.id) // Ensure user can only see their own applications
-        .single()
+      const response = await applicationService.getById(id as string)
 
-      if (applicationError) {
+      if (!response.application) {
         throw new Error('Application not found or access denied')
       }
 
-      setApplication(applicationData)
+      setApplication(response.application as ApplicationWithDetails)
 
 
     } catch (error: any) {


### PR DESCRIPTION
## Summary
- add shared Supabase admin/auth clients and new API routes for applications bulk operations and catalog lookups
- refresh applications REST handlers and analytics to query applications_new with filtering, stats, and role-aware responses
- refactor API client, hooks, and admin/student pages to consume the new REST endpoints instead of direct Supabase queries

## Testing
- npm run lint *(fails: missing package 'typescript-eslint' referenced by eslint.config.js)*
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68ca90beab148332b6eb96b7657ee877