### PR TITLE
Normalize Supabase auth token handling

### DIFF
--- a/src/hooks/useApiServices.ts
+++ b/src/hooks/useApiServices.ts
@@ -1,19 +1,23 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { authService, applicationService, documentService, analyticsService } from '@/services/apiClient'
+import { useAuth } from '@/contexts/AuthContext'
+import { applicationService, documentService, analyticsService } from '@/services/apiClient'
 
 // Auth hooks
 export const useLogin = () => {
+  const { signIn } = useAuth()
+
   return useMutation({
-    mutationFn: authService.login,
-    onSuccess: (data) => {
-      localStorage.setItem('supabase.auth.token', data.session.access_token)
-    }
+    mutationFn: ({ email, password }: { email: string; password: string }) =>
+      signIn(email, password)
   })
 }
 
 export const useRegister = () => {
+  const { signUp } = useAuth()
+
   return useMutation({
-    mutationFn: authService.register
+    mutationFn: ({ email, password, userData }: { email: string; password: string; userData: any }) =>
+      signUp(email, password, userData)
   })
 }
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -46,10 +46,6 @@ supabase.auth.onAuthStateChange(async (event, session) => {
   
   if (event === 'SIGNED_OUT') {
     console.log('User signed out')
-    // Clear any cached data
-    if (typeof window !== 'undefined') {
-      window.localStorage.removeItem('supabase.auth.token')
-    }
   }
   
   if (event === 'SIGNED_IN' && session) {


### PR DESCRIPTION
## Summary
- route the React Query auth hooks through the shared AuthContext so sign-in uses the Supabase session directly
- update the API client to fetch bearer tokens from the active Supabase session rather than a custom localStorage value
- drop the leftover custom token cleanup logic in the Supabase client

## Testing
- npm run lint *(fails: Cannot find package 'typescript-eslint')*


------
https://chatgpt.com/codex/tasks/task_e_68ca9942ca1483329b87e53748e1fd79