### PR TITLE
Fix admin auth token usage

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -172,10 +172,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   async function loadUserProfile(userId: string) {
     try {
-      const { data: session } = await supabase.auth.getSession()
+      const { data: { session } } = await supabase.auth.getSession()
+      const accessToken = session?.access_token
+
+      if (!accessToken) {
+        setProfile(null)
+        return
+      }
+
       const response = await fetch(`/api/admin/users?id=${userId}`, {
         headers: {
-          'Authorization': `Bearer ${session?.access_token}`
+          'Authorization': `Bearer ${accessToken}`
         }
       })
       
@@ -342,10 +349,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         return
       }
 
-      const { data: session } = await supabase.auth.getSession()
+      const { data: { session } } = await supabase.auth.getSession()
+      const accessToken = session?.access_token
+
+      if (!accessToken) {
+        setUserRole(null)
+        return
+      }
+
       const response = await fetch(`/api/admin/users?id=${userId}&action=role`, {
         headers: {
-          'Authorization': `Bearer ${session?.access_token}`
+          'Authorization': `Bearer ${accessToken}`
         }
       })
       


### PR DESCRIPTION
## Summary
- ensure AuthContext retrieves the actual Supabase session object before fetching admin data
- reuse the access token for admin profile and role requests and clear stale state when missing

## Testing
- npm run lint *(fails: Cannot find package 'typescript-eslint' imported from eslint.config.js)*
- npm run test:auth *(fails: No tests found matching tests/auth.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cc18b6e0dc8332ab71b563452c2bb2