### PR TITLE
Guard Supabase client bootstrap for browser environments

### DIFF
--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1,5 +1,5 @@
 import { monitoring } from '@/lib/monitoring'
-import { supabase } from '@/lib/supabase'
+import { getSupabaseClient } from '@/lib/supabase'
 import { getApiBaseUrl } from '@/lib/apiConfig'
 
 const API_BASE = getApiBaseUrl()
@@ -34,6 +34,7 @@ class ApiClient {
     }
 
     try {
+      const supabase = getSupabaseClient()
       const { data: { session } } = await supabase.auth.getSession()
       const token = session?.access_token
       if (token) {


### PR DESCRIPTION
## Summary
- add a Supabase client factory that falls back to in-memory storage when the DOM is unavailable and lazily proxies the exported client
- guard AuthContext initialization to only run in the browser and resolve the client through the new factory
- update the API client to fetch session headers through the bootstrapped Supabase instance

## Testing
- npm run lint *(fails: Cannot find package 'typescript-eslint' imported from eslint.config.js)*
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68cc1a1b022c8332b2cb2cbcca3175c4