### PR TITLE
Refactor enhanced dashboard to use shared metrics

### DIFF
--- a/src/components/admin/EnhancedDashboard.tsx
+++ b/src/components/admin/EnhancedDashboard.tsx
@@ -16,29 +16,46 @@ import {
   ArrowDown
 } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
-import { applicationsData } from '@/data/applications'
 import { analyticsData } from '@/data/analytics'
 
-export function EnhancedDashboard() {
-  const { data: metrics, isLoading: metricsLoading, refetch: refetchMetrics } = applicationsData.useStats()
-  const { data: recentActivity, isLoading: activityLoading } = applicationsData.useRecentActivity()
+export interface EnhancedDashboardMetrics {
+  todayApplications: number
+  pendingApplications: number
+  approvalRate: number
+  avgProcessingTime: number
+  activeUsers: number
+}
+
+export interface EnhancedDashboardActivity {
+  id: string
+  type: 'application' | 'approval' | 'rejection' | 'system'
+  message: string
+  timestamp: string | number
+  user?: string
+}
+
+interface EnhancedDashboardProps {
+  metrics?: EnhancedDashboardMetrics | null
+  recentActivity?: EnhancedDashboardActivity[]
+  onRefresh?: () => void
+  isRefreshing?: boolean
+}
+
+export function EnhancedDashboard({
+  metrics,
+  recentActivity = [],
+  onRefresh,
+  isRefreshing = false
+}: EnhancedDashboardProps) {
   const { data: systemHealth } = analyticsData.useSystemHealth()
 
-  const loading = metricsLoading || activityLoading
-  
-  const refreshData = () => {
-    refetchMetrics()
-  }
-
-  if (loading) {
+  if (!metrics) {
     return (
-      <div className="flex items-center justify-center p-8">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+      <div className="bg-white rounded-xl p-6 shadow-lg border border-gray-100">
+        <p className="text-sm text-gray-500">Dashboard metrics are not available right now.</p>
       </div>
     )
   }
-
-  if (!metrics) return null
 
   return (
     <div className="space-y-6">
@@ -81,12 +98,12 @@ export function EnhancedDashboard() {
                 <Clock className="h-6 w-6 text-yellow-600" />
               </div>
               <div className="text-right">
-                <div className="text-2xl font-bold text-gray-900">{metrics.pendingReviews}</div>
+                <div className="text-2xl font-bold text-gray-900">{metrics.pendingApplications}</div>
                 <div className="text-xs text-gray-500">Pending</div>
               </div>
             </div>
             <div className="text-sm font-medium text-gray-600">Awaiting Review</div>
-            {metrics.pendingReviews > 0 && (
+            {metrics.pendingApplications > 0 && (
               <div className="text-xs text-yellow-600 mt-2">Requires attention</div>
             )}
           </div>
@@ -156,7 +173,9 @@ export function EnhancedDashboard() {
             <Button
               variant="ghost"
               size="sm"
-              onClick={refreshData}
+              onClick={onRefresh}
+              disabled={!onRefresh}
+              loading={isRefreshing}
             >
               <RefreshCw className="h-4 w-4" />
             </Button>

--- a/src/pages/admin/Dashboard.tsx
+++ b/src/pages/admin/Dashboard.tsx
@@ -34,7 +34,7 @@ import {
 import { motion, AnimatePresence } from 'framer-motion'
 import { Link } from 'react-router-dom'
 import { useAnalytics } from '@/hooks/useAnalytics'
-import { EnhancedDashboard } from '@/components/admin/EnhancedDashboard'
+import { EnhancedDashboard, type EnhancedDashboardMetrics } from '@/components/admin/EnhancedDashboard'
 import { QuickActionsPanel } from '@/components/admin/QuickActionsPanel'
 import { PredictiveDashboard } from '@/components/admin/PredictiveDashboard'
 import { workflowAutomation } from '@/lib/workflowAutomation'
@@ -184,6 +184,16 @@ export default function AdminDashboard() {
 
 
   const gridClasses = isMobile ? 'grid-cols-1 gap-4' : 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'
+
+  const enhancedMetrics: EnhancedDashboardMetrics = {
+    todayApplications: stats.todayApplications,
+    pendingApplications: stats.pendingApplications,
+    approvalRate: stats.approvedApplications + stats.rejectedApplications > 0
+      ? Math.round((stats.approvedApplications / (stats.approvedApplications + stats.rejectedApplications)) * 100)
+      : 0,
+    avgProcessingTime: stats.avgProcessingTime,
+    activeUsers: stats.activeUsers
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50">
@@ -407,7 +417,12 @@ export default function AdminDashboard() {
         {/* Enhanced Dashboard Content */}
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-8">
           <div className="lg:col-span-2">
-            <EnhancedDashboard />
+            <EnhancedDashboard
+              metrics={enhancedMetrics}
+              recentActivity={recentActivity}
+              onRefresh={refreshDashboard}
+              isRefreshing={refreshing}
+            />
           </div>
 
           {/* Enhanced Sidebar */}


### PR DESCRIPTION
## Summary
- update the enhanced dashboard component to accept metrics and activity data via props and reuse the parent refresh handler
- wire the admin dashboard pages to pass metrics/activity returned from `adminDashboardService.getMetrics`
- replace redundant Supabase queries in the enhanced admin dashboard page with the shared metrics API and surface refresh/loading states consistently

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68cc234503a48332bf9dfc8f5afec4ba