### PR TITLE
Remove artificial delay from AI assistant responses

### DIFF
--- a/src/components/application/AIAssistant.tsx
+++ b/src/components/application/AIAssistant.tsx
@@ -271,9 +271,6 @@ export function AIAssistant({ applicationData, currentStep, onSuggestionApply, o
 
   const generateResponse = async (userMessage: string): Promise<string> => {
     try {
-      // Use local AI processing (100% free)
-      await new Promise(resolve => setTimeout(resolve, 800 + Math.random() * 1200))
-      
       // Generate intelligent response using local AI
       return localAI.generateResponse(userMessage, {
         applicationData,


### PR DESCRIPTION
## Summary
- remove the simulated delay from `generateResponse` so the assistant replies immediately

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc3330c01c833280bbacad67f8d27a