### PR TITLE
Add payment verification audit trail to admin flows

### DIFF
--- a/src/components/admin/applications/ApplicationDetailModal.tsx
+++ b/src/components/admin/applications/ApplicationDetailModal.tsx
@@ -24,6 +24,14 @@ interface ApplicationWithDetails {
   application_fee?: number
   payer_name?: string
   payment_status?: string
+  payment_verified_at?: string | null
+  payment_verified_by_name?: string | null
+  payment_verified_by_email?: string | null
+  last_payment_audit_at?: string | null
+  last_payment_audit_by_name?: string | null
+  last_payment_audit_by_email?: string | null
+  last_payment_audit_notes?: string | null
+  last_payment_reference?: string | null
   status: string
   submitted_at?: string
   result_slip_url?: string
@@ -206,6 +214,30 @@ export function ApplicationDetailModal({
                     <p><strong>Amount:</strong> K{application.amount || application.application_fee || 'Not provided'}</p>
                     <p><strong>Payer:</strong> {application.payer_name || 'Not provided'}</p>
                     <p><strong>Status:</strong> {application.payment_status || 'Not provided'}</p>
+                    {application.payment_verified_at && (
+                      <p>
+                        <strong>Verified:</strong>{' '}
+                        {new Date(application.payment_verified_at).toLocaleString()}
+                        {(application.payment_verified_by_name || application.payment_verified_by_email) && (
+                          <>
+                            {' '}by{' '}
+                            {application.payment_verified_by_name || application.payment_verified_by_email}
+                          </>
+                        )}
+                      </p>
+                    )}
+                    {application.last_payment_audit_at && (
+                      <p>
+                        <strong>Ledger Entry:</strong>{' '}
+                        {new Date(application.last_payment_audit_at).toLocaleString()}
+                        {application.last_payment_reference && ` • Ref: ${application.last_payment_reference}`}
+                      </p>
+                    )}
+                    {application.last_payment_audit_notes && (
+                      <p>
+                        <strong>Ledger Notes:</strong> {application.last_payment_audit_notes}
+                      </p>
+                    )}
                   </div>
                 </div>
                 <div>

--- a/src/hooks/admin/useApplicationsData.ts
+++ b/src/hooks/admin/useApplicationsData.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { supabase } from '@/lib/supabase'
+import { applicationService } from '@/services/applications'
 
 interface ApplicationSummary {
   id: string
@@ -12,6 +13,16 @@ interface ApplicationSummary {
   institution: string
   status: string
   payment_status: string
+  payment_verified_at: string | null
+  payment_verified_by: string | null
+  payment_verified_by_name: string | null
+  payment_verified_by_email: string | null
+  last_payment_audit_id: number | null
+  last_payment_audit_at: string | null
+  last_payment_audit_by_name: string | null
+  last_payment_audit_by_email: string | null
+  last_payment_audit_notes: string | null
+  last_payment_reference: string | null
   application_fee: number
   paid_amount: number
   submitted_at: string
@@ -60,22 +71,12 @@ export function useApplicationsData() {
   }
 
   const updateStatus = async (applicationId: string, newStatus: string) => {
-    const { error } = await supabase
-      .from('applications_new')
-      .update({ status: newStatus })
-      .eq('id', applicationId)
-
-    if (error) throw error
+    await applicationService.updateStatus(applicationId, newStatus)
     await loadApplications()
   }
 
-  const updatePaymentStatus = async (applicationId: string, newPaymentStatus: string) => {
-    const { error } = await supabase
-      .from('applications_new')
-      .update({ payment_status: newPaymentStatus })
-      .eq('id', applicationId)
-
-    if (error) throw error
+  const updatePaymentStatus = async (applicationId: string, newPaymentStatus: string, verificationNotes?: string) => {
+    await applicationService.updatePaymentStatus(applicationId, newPaymentStatus, verificationNotes)
     await loadApplications()
   }
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -299,7 +299,9 @@ export interface Application {
   momo_ref?: string
   pop_url?: string
   payment_status: 'pending_review' | 'verified' | 'rejected'
-  
+  payment_verified_at?: string | null
+  payment_verified_by?: string | null
+
   // Step 4: Status tracking
   status: 'draft' | 'submitted' | 'under_review' | 'approved' | 'rejected'
   submitted_at?: string

--- a/src/pages/admin/ApplicationsAdmin.tsx
+++ b/src/pages/admin/ApplicationsAdmin.tsx
@@ -20,6 +20,16 @@ interface ApplicationSummary {
   institution: string
   status: string
   payment_status: string
+  payment_verified_at: string | null
+  payment_verified_by: string | null
+  payment_verified_by_name: string | null
+  payment_verified_by_email: string | null
+  last_payment_audit_id: number | null
+  last_payment_audit_at: string | null
+  last_payment_audit_by_name: string | null
+  last_payment_audit_by_email: string | null
+  last_payment_audit_notes: string | null
+  last_payment_reference: string | null
   application_fee: number
   paid_amount: number
   submitted_at: string

--- a/src/services/applications.ts
+++ b/src/services/applications.ts
@@ -38,10 +38,14 @@ export const applicationService = {
       body: JSON.stringify({ action: 'update_status', status, notes })
     }),
 
-  updatePaymentStatus: (id: string, paymentStatus: string) =>
+  updatePaymentStatus: (id: string, paymentStatus: string, verificationNotes?: string) =>
     apiClient.request(`/api/applications/${id}`, {
       method: 'PATCH',
-      body: JSON.stringify({ action: 'update_payment_status', paymentStatus })
+      body: JSON.stringify({
+        action: 'update_payment_status',
+        paymentStatus,
+        ...(verificationNotes ? { verificationNotes } : {})
+      })
     }),
 
   verifyDocument: (


### PR DESCRIPTION
## Summary
- add payment verification metadata updates and audit logging when payment statuses are verified via the applications API
- extend the Supabase schema and admin data hook to expose payment verification and ledger fields
- surface payment verification and ledger details in the admin applications table and detail modal for finance review

## Testing
- npm run lint *(fails: existing lint errors and warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc329b4e3883328f077dfaf40fc34c