### PR TITLE
Improve admin applications pagination experience

### DIFF
--- a/src/components/admin/applications/ApplicationsTable.tsx
+++ b/src/components/admin/applications/ApplicationsTable.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { sanitizeHtml } from '@/lib/sanitizer'
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 
 interface ApplicationSummary {
   id: string
@@ -25,14 +26,40 @@ interface ApplicationSummary {
 
 interface ApplicationsTableProps {
   applications: ApplicationSummary[]
+  totalCount: number
+  loadedCount: number
+  loadedPageCount: number
+  currentPage: number
+  totalPages: number
+  pageSize: number
+  hasMore: boolean
+  isLoadingMore: boolean
+  isFiltered: boolean
+  isRefreshing: boolean
+  onLoadMore: () => void
+  onRefresh: () => void
+  onPageSizeChange: (pageSize: number) => void
   onStatusUpdate: (id: string, status: string) => void
   onPaymentStatusUpdate: (id: string, status: string) => void
 }
 
-export function ApplicationsTable({ 
-  applications, 
-  onStatusUpdate, 
-  onPaymentStatusUpdate 
+export function ApplicationsTable({
+  applications,
+  totalCount,
+  loadedCount,
+  loadedPageCount,
+  currentPage,
+  totalPages,
+  pageSize,
+  hasMore,
+  isLoadingMore,
+  isFiltered,
+  isRefreshing,
+  onLoadMore,
+  onRefresh,
+  onPageSizeChange,
+  onStatusUpdate,
+  onPaymentStatusUpdate
 }: ApplicationsTableProps) {
   const getStatusBadge = (status: string) => {
     const colors = {
@@ -63,6 +90,15 @@ export function ApplicationsTable({
       </span>
     )
   }
+
+  const summaryText = isFiltered
+    ? `Showing ${applications.length} matching application${applications.length === 1 ? '' : 's'} from ${loadedCount} loaded across ${loadedPageCount} page${loadedPageCount === 1 ? '' : 's'}`
+    : `Loaded ${loadedCount} of ${totalCount} applications • ${loadedPageCount} page${loadedPageCount === 1 ? '' : 's'} loaded • Page ${Math.max(currentPage, 1)} of ${Math.max(totalPages, 1)} • ${pageSize} per page`
+
+  const defaultPageSizeOptions = [10, 25, 50, 100]
+  const pageSizeOptions = defaultPageSizeOptions.includes(pageSize)
+    ? defaultPageSizeOptions
+    : [...defaultPageSizeOptions, pageSize].sort((a, b) => a - b)
 
   return (
     <div className="bg-white rounded-lg shadow overflow-hidden">
@@ -211,6 +247,44 @@ export function ApplicationsTable({
           <div className="text-gray-500">No applications found matching your criteria.</div>
         </div>
       )}
+
+      <div className="px-6 py-4 border-t border-gray-200 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="text-sm text-gray-500">{summaryText}</div>
+        <div className="flex flex-wrap gap-3">
+          <label className="flex items-center gap-2 text-sm text-gray-600">
+            <span>Rows per page</span>
+            <select
+              value={pageSize}
+              onChange={(event) => onPageSizeChange(Number(event.target.value))}
+              className="rounded border-gray-300 text-sm focus:border-blue-500 focus:ring-blue-500"
+            >
+              {pageSizeOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            onClick={onRefresh}
+            disabled={isRefreshing}
+            className="inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-400"
+          >
+            {isRefreshing && <LoadingSpinner size="sm" className="mr-2" />}
+            Refresh
+          </button>
+          <button
+            type="button"
+            onClick={onLoadMore}
+            disabled={!hasMore || isLoadingMore}
+            className="inline-flex items-center justify-center rounded-md border border-blue-600 bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:border-blue-300 disabled:bg-blue-300"
+          >
+            {isLoadingMore && <LoadingSpinner size="sm" className="mr-2" />}
+            {hasMore ? (isLoadingMore ? 'Loading…' : 'Load more') : 'No more results'}
+          </button>
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/hooks/admin/useApplicationsData.ts
+++ b/src/hooks/admin/useApplicationsData.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { supabase } from '@/lib/supabase'
 
 interface ApplicationSummary {
@@ -27,68 +27,210 @@ interface ApplicationSummary {
 }
 
 export function useApplicationsData() {
-  const [applications, setApplications] = useState<ApplicationSummary[]>([])
+  const [pages, setPages] = useState<Record<number, ApplicationSummary[]>>({})
   const [isInitialLoading, setIsInitialLoading] = useState(true)
   const [isRefreshing, setIsRefreshing] = useState(false)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
   const [error, setError] = useState('')
+  const [pageSize, setPageSize] = useState(25)
+  const [currentPage, setCurrentPage] = useState(0)
+  const [totalCount, setTotalCount] = useState(0)
+  const applications = useMemo(() => {
+    return Object.keys(pages)
+      .map(Number)
+      .sort((a, b) => a - b)
+      .flatMap((page) => pages[page] ?? [])
+  }, [pages])
+  const loadedPageNumbers = useMemo(
+    () =>
+      Object.keys(pages)
+        .map(Number)
+        .sort((a, b) => a - b),
+    [pages]
+  )
+  const loadedPageCount = loadedPageNumbers.length
+  const loadedCount = applications.length
+  const hasMore = loadedCount < totalCount
+  const totalPages = pageSize > 0 ? Math.ceil(totalCount / pageSize) : 0
+  const latestLoadedPage = loadedPageNumbers[loadedPageNumbers.length - 1] ?? 0
 
-  const loadApplications = async () => {
-    const isFirstLoad = isInitialLoading
-    try {
-      setError('')
-      if (isFirstLoad) {
-        setIsInitialLoading(true)
-      } else {
-        setIsRefreshing(true)
+  const findPageForApplication = useCallback(
+    (applicationId: string) => {
+      for (const [page, pageItems] of Object.entries(pages)) {
+        if (pageItems.some(app => app.id === applicationId)) {
+          return Number(page)
+        }
       }
-      const { data, error } = await supabase
-        .from('admin_application_detailed')
-        .select('*')
-        .order('created_at', { ascending: false })
+      return null
+    },
+    [pages]
+  )
 
-      if (error) throw error
-      setApplications(data || [])
+  const fetchPage = useCallback(
+    async (page: number, { reset = false, updateCurrentPage = true } = {}) => {
+      const safePage = Math.max(page, 1)
+      const start = (safePage - 1) * pageSize
+      const end = start + pageSize - 1
+
+      if (reset) {
+        setPages({})
+        setCurrentPage(0)
+        setTotalCount(0)
+      }
+
+      const { data, count, error: fetchError } = await supabase
+        .from('admin_application_detailed')
+        .select('*', { count: 'exact' })
+        .order('created_at', { ascending: false })
+        .range(start, Math.max(end, start))
+
+      if (fetchError) throw fetchError
+
+      if (typeof count === 'number') {
+        setTotalCount(count)
+      }
+
+      const pageData = data ?? []
+
+      setPages(prevPages => {
+        const nextPages: Record<number, ApplicationSummary[]> = reset
+          ? {}
+          : { ...prevPages }
+        nextPages[safePage] = pageData
+        return nextPages
+      })
+
+      if (updateCurrentPage) {
+        setCurrentPage(safePage)
+      }
+
+      return pageData
+    },
+    [pageSize]
+  )
+
+  const loadInitialPage = useCallback(async () => {
+    setError('')
+    setIsInitialLoading(true)
+    try {
+      await fetchPage(1, { reset: true })
     } catch (err: any) {
       setError(err.message)
     } finally {
-      if (isFirstLoad) {
-        setIsInitialLoading(false)
-      } else {
-        setIsRefreshing(false)
+      setIsInitialLoading(false)
+    }
+  }, [fetchPage])
+
+  const refreshCurrentPage = useCallback(async () => {
+    if (loadedPageCount === 0) {
+      await loadInitialPage()
+      return
+    }
+
+    setError('')
+    setIsRefreshing(true)
+    try {
+      for (const pageNumber of loadedPageNumbers) {
+        const isLastPage = pageNumber === latestLoadedPage
+        await fetchPage(pageNumber, {
+          updateCurrentPage: isLastPage
+        })
       }
+    } catch (err: any) {
+      setError(err.message)
+    } finally {
+      setIsRefreshing(false)
+    }
+  }, [fetchPage, latestLoadedPage, loadInitialPage, loadedPageCount, loadedPageNumbers])
+
+  const loadNextPage = useCallback(async () => {
+    if (isLoadingMore || !hasMore) return
+    setError('')
+    setIsLoadingMore(true)
+    try {
+      const nextPage = latestLoadedPage === 0 ? 1 : latestLoadedPage + 1
+      await fetchPage(nextPage, { updateCurrentPage: true })
+    } catch (err: any) {
+      setError(err.message)
+    } finally {
+      setIsLoadingMore(false)
+    }
+  }, [fetchPage, hasMore, isLoadingMore, latestLoadedPage])
+
+  const updateStatus = async (applicationId: string, newStatus: string) => {
+    setError('')
+    try {
+      const { error: updateError } = await supabase
+        .from('applications_new')
+        .update({ status: newStatus })
+        .eq('id', applicationId)
+
+      if (updateError) throw updateError
+
+      const pageToRefresh = findPageForApplication(applicationId)
+      const targetPage = pageToRefresh ?? (latestLoadedPage || 1)
+      await fetchPage(targetPage, {
+        updateCurrentPage: pageToRefresh === null ? true : targetPage >= latestLoadedPage
+      })
+    } catch (err: any) {
+      setError(err.message)
+      throw err
     }
   }
 
-  const updateStatus = async (applicationId: string, newStatus: string) => {
-    const { error } = await supabase
-      .from('applications_new')
-      .update({ status: newStatus })
-      .eq('id', applicationId)
-
-    if (error) throw error
-    await loadApplications()
-  }
-
   const updatePaymentStatus = async (applicationId: string, newPaymentStatus: string) => {
-    const { error } = await supabase
-      .from('applications_new')
-      .update({ payment_status: newPaymentStatus })
-      .eq('id', applicationId)
+    setError('')
+    try {
+      const { error: updateError } = await supabase
+        .from('applications_new')
+        .update({ payment_status: newPaymentStatus })
+        .eq('id', applicationId)
 
-    if (error) throw error
-    await loadApplications()
+      if (updateError) throw updateError
+
+      const pageToRefresh = findPageForApplication(applicationId)
+      const targetPage = pageToRefresh ?? (latestLoadedPage || 1)
+      await fetchPage(targetPage, {
+        updateCurrentPage: pageToRefresh === null ? true : targetPage >= latestLoadedPage
+      })
+    } catch (err: any) {
+      setError(err.message)
+      throw err
+    }
   }
+
+  const hasLoadedRef = useRef(false)
 
   useEffect(() => {
-    loadApplications()
-  }, [])
+    const runInitialLoad = async () => {
+      await loadInitialPage()
+      hasLoadedRef.current = true
+    }
+
+    runInitialLoad()
+  }, [loadInitialPage])
+
+  useEffect(() => {
+    if (!hasLoadedRef.current) return
+    loadInitialPage()
+  }, [pageSize, loadInitialPage])
 
   return {
     applications,
     isInitialLoading,
     isRefreshing,
+    isLoadingMore,
     error,
-    loadApplications,
+    pageSize,
+    setPageSize,
+    currentPage,
+    totalPages,
+    totalCount,
+    hasMore,
+    loadedCount,
+    loadedPageCount,
+    loadNextPage,
+    refreshCurrentPage,
     updateStatus,
     updatePaymentStatus
   }

--- a/src/pages/admin/Applications.tsx
+++ b/src/pages/admin/Applications.tsx
@@ -13,16 +13,29 @@ export default function Applications() {
     applications,
     isInitialLoading,
     isRefreshing,
+    isLoadingMore,
     error,
+    totalCount,
+    currentPage,
+    totalPages,
+    pageSize,
+    hasMore,
+    loadedCount,
+    loadedPageCount,
+    loadNextPage,
+    refreshCurrentPage,
     updateStatus,
-    updatePaymentStatus
+    updatePaymentStatus,
+    setPageSize
   } = useApplicationsData()
 
-  const { 
-    filters, 
-    updateFilter, 
-    filteredApplications 
+  const {
+    filters,
+    updateFilter,
+    filteredApplications
   } = useApplicationFilters(applications)
+
+  const isFiltered = Object.values(filters).some(Boolean)
 
   return (
     <div className="min-h-screen bg-gray-50 py-8">
@@ -66,6 +79,19 @@ export default function Applications() {
 
             <ApplicationsTable
               applications={filteredApplications}
+              totalCount={totalCount}
+              loadedCount={loadedCount}
+              loadedPageCount={loadedPageCount}
+              currentPage={currentPage}
+              totalPages={totalPages}
+              pageSize={pageSize}
+              hasMore={hasMore}
+              isLoadingMore={isLoadingMore}
+              isFiltered={isFiltered}
+              isRefreshing={isRefreshing}
+              onLoadMore={loadNextPage}
+              onRefresh={refreshCurrentPage}
+              onPageSizeChange={setPageSize}
               onStatusUpdate={updateStatus}
               onPaymentStatusUpdate={updatePaymentStatus}
             />


### PR DESCRIPTION
## Summary
- restructure the admin applications data hook to cache individual pages, derive pagination metadata, and refresh/update only the relevant slices
- extend the applications table with richer pagination summaries plus a selectable page size control wired into the hook helpers
- plumb the enhanced pagination state through the admin applications page so filters and controls stay in sync

## Testing
- npm run lint *(fails: existing warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3330d59c83329d6df59ee4118d21