### PR TITLE
Add pagination support for admin applications

### DIFF
--- a/src/components/admin/applications/ApplicationsTable.tsx
+++ b/src/components/admin/applications/ApplicationsTable.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { sanitizeHtml } from '@/lib/sanitizer'
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 
 interface ApplicationSummary {
   id: string
@@ -35,12 +36,22 @@ interface ApplicationSummary {
 
 interface ApplicationsTableProps {
   applications: ApplicationSummary[]
+  totalCount: number
+  loadedCount: number
+  hasMore: boolean
+  isLoadingMore: boolean
+  onLoadMore: () => void | Promise<void>
   onStatusUpdate: (id: string, status: string) => void
   onPaymentStatusUpdate: (id: string, status: string) => void
 }
 
 export function ApplicationsTable({
   applications,
+  totalCount,
+  loadedCount,
+  hasMore,
+  isLoadingMore,
+  onLoadMore,
   onStatusUpdate,
   onPaymentStatusUpdate
 }: ApplicationsTableProps) {
@@ -260,6 +271,35 @@ export function ApplicationsTable({
           <div className="text-gray-500">No applications found matching your criteria.</div>
         </div>
       )}
+
+      <div className="border-t border-gray-200 bg-gray-50 px-6 py-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="text-sm text-gray-500">
+          Showing <span className="font-semibold text-gray-700">{loadedCount}</span>
+          {totalCount > 0 && (
+            <>
+              {' '}of{' '}
+              <span className="font-semibold text-gray-700">{totalCount}</span>
+            </>
+          )}{' '}
+          applications
+        </div>
+
+        {hasMore ? (
+          <button
+            type="button"
+            onClick={onLoadMore}
+            disabled={isLoadingMore}
+            className="inline-flex items-center justify-center rounded-md border border-blue-600 bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {isLoadingMore && <LoadingSpinner size="sm" className="mr-2" />}
+            {isLoadingMore ? 'Loading more...' : 'Load more applications'}
+          </button>
+        ) : (
+          totalCount > 0 && (
+            <span className="text-sm text-gray-400">All applications loaded.</span>
+          )
+        )}
+      </div>
     </div>
   )
 }

--- a/src/components/admin/applications/MetricsHeader.tsx
+++ b/src/components/admin/applications/MetricsHeader.tsx
@@ -7,37 +7,43 @@ interface ApplicationSummary {
 
 interface MetricsHeaderProps {
   applications: ApplicationSummary[]
+  totalCount: number
 }
 
-export function MetricsHeader({ applications }: MetricsHeaderProps) {
+export function MetricsHeader({ applications, totalCount }: MetricsHeaderProps) {
+  const loadedCount = applications.length
+
   return (
     <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
       <div className="bg-white rounded-lg shadow p-6">
         <div className="text-2xl font-bold text-gray-900">
-          {applications.length}
+          {totalCount}
         </div>
         <div className="text-sm text-gray-500">Total Applications</div>
+        <div className="text-xs text-gray-400 mt-1">
+          Showing {loadedCount} loaded
+        </div>
       </div>
-      
+
       <div className="bg-white rounded-lg shadow p-6">
         <div className="text-2xl font-bold text-blue-600">
           {applications.filter(app => app.status === 'submitted').length}
         </div>
-        <div className="text-sm text-gray-500">Submitted</div>
+        <div className="text-sm text-gray-500">Submitted (loaded)</div>
       </div>
-      
+
       <div className="bg-white rounded-lg shadow p-6">
         <div className="text-2xl font-bold text-yellow-600">
           {applications.filter(app => app.payment_status === 'pending_review').length}
         </div>
-        <div className="text-sm text-gray-500">Pending Payment Review</div>
+        <div className="text-sm text-gray-500">Pending Payment Review (loaded)</div>
       </div>
-      
+
       <div className="bg-white rounded-lg shadow p-6">
         <div className="text-2xl font-bold text-green-600">
           {applications.filter(app => app.status === 'approved').length}
         </div>
-        <div className="text-sm text-gray-500">Approved</div>
+        <div className="text-sm text-gray-500">Approved (loaded)</div>
       </div>
     </div>
   )

--- a/src/hooks/admin/useApplicationFilters.ts
+++ b/src/hooks/admin/useApplicationFilters.ts
@@ -1,17 +1,6 @@
-import { useState, useMemo } from 'react'
+import { useState } from 'react'
 
-interface ApplicationSummary {
-  id: string
-  application_number: string
-  full_name: string
-  email: string
-  status: string
-  payment_status: string
-  program: string
-  institution: string
-}
-
-interface FilterState {
+export interface ApplicationFilters {
   searchTerm: string
   statusFilter: string
   paymentFilter: string
@@ -19,38 +8,28 @@ interface FilterState {
   institutionFilter: string
 }
 
-export function useApplicationFilters(applications: ApplicationSummary[]) {
-  const [filters, setFilters] = useState<FilterState>({
-    searchTerm: '',
-    statusFilter: '',
-    paymentFilter: '',
-    programFilter: '',
-    institutionFilter: ''
-  })
+export const DEFAULT_APPLICATION_FILTERS: ApplicationFilters = {
+  searchTerm: '',
+  statusFilter: '',
+  paymentFilter: '',
+  programFilter: '',
+  institutionFilter: ''
+}
 
-  const updateFilter = (key: keyof FilterState, value: string) => {
+export function useApplicationFilters() {
+  const [filters, setFilters] = useState<ApplicationFilters>({ ...DEFAULT_APPLICATION_FILTERS })
+
+  const updateFilter = (key: keyof ApplicationFilters, value: string) => {
     setFilters(prev => ({ ...prev, [key]: value }))
   }
 
-  const filteredApplications = useMemo(() => {
-    return applications.filter(app => {
-      const matchesSearch = !filters.searchTerm || 
-        app.full_name.toLowerCase().includes(filters.searchTerm.toLowerCase()) ||
-        app.email.toLowerCase().includes(filters.searchTerm.toLowerCase()) ||
-        app.application_number.toLowerCase().includes(filters.searchTerm.toLowerCase())
-      
-      const matchesStatus = !filters.statusFilter || app.status === filters.statusFilter
-      const matchesPayment = !filters.paymentFilter || app.payment_status === filters.paymentFilter
-      const matchesProgram = !filters.programFilter || app.program === filters.programFilter
-      const matchesInstitution = !filters.institutionFilter || app.institution === filters.institutionFilter
-
-      return matchesSearch && matchesStatus && matchesPayment && matchesProgram && matchesInstitution
-    })
-  }, [applications, filters])
+  const resetFilters = () => {
+    setFilters({ ...DEFAULT_APPLICATION_FILTERS })
+  }
 
   return {
     filters,
     updateFilter,
-    filteredApplications
+    resetFilters
   }
 }

--- a/src/pages/admin/Applications.tsx
+++ b/src/pages/admin/Applications.tsx
@@ -11,19 +11,22 @@ import { useApplicationsData, useApplicationFilters } from '@/hooks/admin'
 
 export default function Applications() {
   const {
+    filters,
+    updateFilter
+  } = useApplicationFilters()
+
+  const {
     applications,
     isInitialLoading,
     isRefreshing,
+    isLoadingMore,
     error,
+    pagination,
+    hasMore,
+    loadNextPage,
     updateStatus,
     updatePaymentStatus
-  } = useApplicationsData()
-
-  const { 
-    filters, 
-    updateFilter, 
-    filteredApplications 
-  } = useApplicationFilters(applications)
+  } = useApplicationsData(filters)
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50">
@@ -52,7 +55,10 @@ export default function Applications() {
               <ApplicationsSkeleton />
             ) : (
               <div className="space-y-6">
-                <MetricsHeader applications={applications} />
+                <MetricsHeader
+                  applications={applications}
+                  totalCount={pagination.totalCount}
+                />
 
                 {isRefreshing && (
                   <div className="flex items-center gap-2 rounded-lg bg-blue-50 px-4 py-3 text-sm text-blue-600">
@@ -71,7 +77,12 @@ export default function Applications() {
                 />
 
                 <ApplicationsTable
-                  applications={filteredApplications}
+                  applications={applications}
+                  totalCount={pagination.totalCount}
+                  loadedCount={pagination.loadedCount}
+                  hasMore={hasMore}
+                  isLoadingMore={isLoadingMore}
+                  onLoadMore={loadNextPage}
                   onStatusUpdate={updateStatus}
                   onPaymentStatusUpdate={updatePaymentStatus}
                 />

--- a/src/pages/admin/ApplicationsAdmin.tsx
+++ b/src/pages/admin/ApplicationsAdmin.tsx
@@ -49,8 +49,12 @@ export default function ApplicationsAdmin() {
     applications,
     isInitialLoading,
     isRefreshing,
+    isLoadingMore,
     error: dataError,
     loadApplications,
+    loadNextPage,
+    hasMore,
+    pagination,
     updateStatus: updateApplicationStatus,
     updatePaymentStatus: updateApplicationPaymentStatus
   } = useApplicationsData()
@@ -427,41 +431,75 @@ export default function ApplicationsAdmin() {
             </table>
           </div>
           
-          {filteredApplications.length === 0 && (
-            <div className="text-center py-12">
-              <div className="text-gray-500">No applications found matching your criteria.</div>
+            {filteredApplications.length === 0 && (
+              <div className="text-center py-12">
+                <div className="text-gray-500">No applications found matching your criteria.</div>
+              </div>
+            )}
+            <div className="border-t border-gray-200 bg-gray-50 px-6 py-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="text-sm text-gray-500">
+                Showing{' '}
+                <span className="font-semibold text-gray-700">{filteredApplications.length}</span>
+                {' '}of{' '}
+                <span className="font-semibold text-gray-700">{pagination.loadedCount}</span>{' '}
+                loaded
+                {pagination.totalCount > 0 && (
+                  <>
+                    {' '}•{' '}
+                    <span className="font-semibold text-gray-700">{pagination.totalCount}</span>{' '}
+                    total
+                  </>
+                )}{' '}
+                applications
+              </div>
+
+              {hasMore ? (
+                <button
+                  type="button"
+                  onClick={loadNextPage}
+                  disabled={isLoadingMore}
+                  className="inline-flex items-center justify-center rounded-md border border-blue-600 bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 disabled:opacity-60 disabled:cursor-not-allowed"
+                >
+                  {isLoadingMore && <LoadingSpinner size="sm" className="mr-2" />}
+                  {isLoadingMore ? 'Loading more...' : 'Load more applications'}
+                </button>
+              ) : (
+                pagination.totalCount > 0 && (
+                  <span className="text-sm text-gray-400">All applications loaded.</span>
+                )
+              )}
             </div>
-          )}
-        </div>
+          </div>
 
             {/* Summary Stats */}
             <div className="mt-8 grid grid-cols-1 md:grid-cols-4 gap-6">
               <div className="bg-white rounded-lg shadow p-6">
                 <div className="text-2xl font-bold text-gray-900">
-                  {applications.length}
+                  {pagination.totalCount}
                 </div>
                 <div className="text-sm text-gray-500">Total Applications</div>
+                <div className="text-xs text-gray-400 mt-1">Loaded: {applications.length}</div>
               </div>
 
               <div className="bg-white rounded-lg shadow p-6">
                 <div className="text-2xl font-bold text-blue-600">
                   {applications.filter(app => app.status === 'submitted').length}
                 </div>
-                <div className="text-sm text-gray-500">Submitted</div>
+                <div className="text-sm text-gray-500">Submitted (loaded)</div>
               </div>
 
               <div className="bg-white rounded-lg shadow p-6">
                 <div className="text-2xl font-bold text-yellow-600">
                   {applications.filter(app => app.payment_status === 'pending_review').length}
                 </div>
-                <div className="text-sm text-gray-500">Pending Payment Review</div>
+                <div className="text-sm text-gray-500">Pending Payment Review (loaded)</div>
               </div>
 
               <div className="bg-white rounded-lg shadow p-6">
                 <div className="text-2xl font-bold text-green-600">
                   {applications.filter(app => app.status === 'approved').length}
                 </div>
-                <div className="text-sm text-gray-500">Approved</div>
+                <div className="text-sm text-gray-500">Approved (loaded)</div>
               </div>
             </div>
           </>


### PR DESCRIPTION
## Summary
- add pagination state management and server-side filtering to `useApplicationsData`
- simplify `useApplicationFilters` to manage filter state for paginated queries
- update admin application pages and tables to use pagination helpers and load-more controls

## Testing
- `npm run lint` *(fails: pre-existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3d6c13308332a6b41cc03ec698a4