### PR TITLE
Optimize landing page background animations

### DIFF
--- a/src/components/ui/FloatingElements.tsx
+++ b/src/components/ui/FloatingElements.tsx
@@ -4,38 +4,29 @@ import { motion, useReducedMotion } from 'framer-motion'
 interface FloatingElementsProps {
   count?: number
   className?: string
+  shouldAnimate?: boolean
 }
 
-const generateElements = (count: number) => Array.from({ length: count }, (_, i) => ({
-  id: i,
-  size: Math.random() * 6 + 3,
-  left: Math.random() * 100,
-  delay: Math.random() * 8,
-  duration: 6 + Math.random() * 4,
-  opacity: 0.1 + Math.random() * 0.3
-}))
+const generateElements = (count: number) =>
+  Array.from({ length: count }, (_, i) => ({
+    id: i,
+    size: Math.random() * 6 + 3,
+    left: Math.random() * 100,
+    top: Math.random() * 100,
+    delay: Math.random() * 8,
+    duration: 6 + Math.random() * 4,
+    opacity: 0.1 + Math.random() * 0.3
+  }))
 
-export const FloatingElements = React.memo(({ count = 20, className = '' }: FloatingElementsProps) => {
+export const FloatingElements = React.memo(({ count = 20, className = '', shouldAnimate = true }: FloatingElementsProps) => {
   const prefersReducedMotion = useReducedMotion()
   const elements = useMemo(() => generateElements(count), [count])
+  const enableAnimation = shouldAnimate && !prefersReducedMotion
 
   return (
     <div className={`absolute inset-0 overflow-hidden pointer-events-none ${className}`}>
       {elements.map((element) => (
-        prefersReducedMotion ? (
-          <div
-            key={element.id}
-            className="absolute rounded-full"
-            style={{
-              width: element.size,
-              height: element.size,
-              left: `${element.left}%`,
-              top: '0%',
-              background: `radial-gradient(circle, rgba(20, 184, 166, ${element.opacity}) 0%, transparent 70%)`,
-              opacity: element.opacity
-            }}
-          />
-        ) : (
+        enableAnimation ? (
           <motion.div
             key={element.id}
             className="absolute rounded-full"
@@ -43,7 +34,8 @@ export const FloatingElements = React.memo(({ count = 20, className = '' }: Floa
               width: element.size,
               height: element.size,
               left: `${element.left}%`,
-              background: `radial-gradient(circle, rgba(20, 184, 166, ${element.opacity}) 0%, transparent 70%)`,
+              top: `${element.top}%`,
+              background: `radial-gradient(circle, rgba(20, 184, 166, ${element.opacity}) 0%, transparent 70%)`
             }}
             animate={{
               y: [-50, -100, -50],
@@ -55,7 +47,20 @@ export const FloatingElements = React.memo(({ count = 20, className = '' }: Floa
               duration: element.duration,
               delay: element.delay,
               repeat: Infinity,
-              ease: "easeInOut"
+              ease: 'easeInOut'
+            }}
+          />
+        ) : (
+          <div
+            key={element.id}
+            className="absolute rounded-full"
+            style={{
+              width: element.size,
+              height: element.size,
+              left: `${element.left}%`,
+              top: `${element.top}%`,
+              background: `radial-gradient(circle, rgba(20, 184, 166, ${element.opacity}) 0%, transparent 70%)`,
+              opacity: element.opacity
             }}
           />
         )

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -22,9 +22,19 @@ export default function LandingPageNew() {
   const shouldReduceMotion = useReducedMotion()
   const [heroRef, heroInView] = useInView({ threshold: 0.3, triggerOnce: true })
   const [statsRef, statsInView] = useInView({ threshold: 0.3, triggerOnce: true })
+  const [statsBackgroundRef, statsBackgroundInView] = useInView({ threshold: 0.1, triggerOnce: false })
+  const [programsBackgroundRef, programsBackgroundInView] = useInView({ threshold: 0.1, triggerOnce: false })
+  const [ctaBackgroundRef, ctaBackgroundInView] = useInView({ threshold: 0.1, triggerOnce: false })
+  const [footerBackgroundRef, footerBackgroundInView] = useInView({ threshold: 0.1, triggerOnce: false })
   const [showAnimations, setShowAnimations] = useState(false)
   const animationHelpersEnabled = showAnimations && !shouldReduceMotion
   const maybeMotion = <T,>(value: T) => (shouldReduceMotion ? undefined : value)
+
+  const heroFloatingCount = isMobile ? 16 : 30
+  const statsFloatingCount = isMobile ? 5 : 10
+  const programsFloatingCount = isMobile ? 8 : 15
+  const ctaFloatingCount = isMobile ? 12 : 25
+  const footerFloatingCount = isMobile ? 4 : 8
   
   useEffect(() => {
     // Defer animations to improve LCP
@@ -125,7 +135,7 @@ export default function LandingPageNew() {
         <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-black/10" />
         {animationHelpersEnabled && (
           <Suspense fallback={null}>
-            <FloatingElements count={30} />
+            <FloatingElements count={heroFloatingCount} />
             <GeometricPatterns />
           </Suspense>
         )}
@@ -199,10 +209,14 @@ export default function LandingPageNew() {
       </section>
 
       {/* Stats Section */}
-      <section id="stats" className="py-20 bg-gray-50 relative">
+      <section id="stats" ref={statsBackgroundRef} className="py-20 bg-gray-50 relative">
         {animationHelpersEnabled && (
           <Suspense fallback={null}>
-            <FloatingElements count={10} className="opacity-30" />
+            <FloatingElements
+              count={statsFloatingCount}
+              className="opacity-30"
+              shouldAnimate={statsBackgroundInView}
+            />
           </Suspense>
         )}
         <motion.div
@@ -428,10 +442,13 @@ export default function LandingPageNew() {
       </section>
 
       {/* Enhanced Programs Section */}
-      <section className="py-20 bg-gray-50 relative">
+      <section ref={programsBackgroundRef} className="py-20 bg-gray-50 relative">
         {animationHelpersEnabled && (
           <Suspense fallback={null}>
-            <FloatingElements count={15} />
+            <FloatingElements
+              count={programsFloatingCount}
+              shouldAnimate={programsBackgroundInView}
+            />
           </Suspense>
         )}
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -544,12 +561,15 @@ export default function LandingPageNew() {
       </section>
 
       {/* Enhanced CTA Section */}
-      <section className="relative py-20 overflow-hidden">
+      <section ref={ctaBackgroundRef} className="relative py-20 overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-r from-primary via-secondary to-accent" />
         <div className="absolute inset-0 bg-gradient-to-b from-transparent via-black/10 to-black/20" />
         {animationHelpersEnabled && (
           <Suspense fallback={null}>
-            <FloatingElements count={25} />
+            <FloatingElements
+              count={ctaFloatingCount}
+              shouldAnimate={ctaBackgroundInView}
+            />
             <GeometricPatterns />
           </Suspense>
         )}
@@ -590,10 +610,14 @@ export default function LandingPageNew() {
       </section>
 
       {/* Enhanced Footer */}
-      <footer className="bg-gray-900 text-white py-16 relative">
+      <footer ref={footerBackgroundRef} className="bg-gray-900 text-white py-16 relative">
         {animationHelpersEnabled && (
           <Suspense fallback={null}>
-            <FloatingElements count={8} className="opacity-20" />
+            <FloatingElements
+              count={footerFloatingCount}
+              className="opacity-20"
+              shouldAnimate={footerBackgroundInView}
+            />
           </Suspense>
         )}
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Summary
- add a `shouldAnimate` escape hatch to `FloatingElements` so sections can render static backgrounds when off-screen
- gate landing page background helpers behind `useInView` and trim particle counts on mobile to keep only the hero active by default

## Testing
- `npm run lint` *(fails: existing repository lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cc45d33018833285bf234544d4604b