### PR TITLE
feat: add document generation actions to admin application modal

### DIFF
--- a/src/components/admin/applications/ApplicationDetailModal.tsx
+++ b/src/components/admin/applications/ApplicationDetailModal.tsx
@@ -54,6 +54,8 @@ interface ApplicationDetailModalProps {
   onViewDocuments: () => void
   onViewHistory: () => void
   onUpdateStatus: (id: string, status: string) => void
+  onGenerateAcceptanceLetter: () => Promise<void>
+  onGenerateFinanceReceipt: () => Promise<void>
 }
 
 function GradesDisplay({ applicationId }: { applicationId: string }) {
@@ -114,9 +116,41 @@ export function ApplicationDetailModal({
   onSendNotification,
   onViewDocuments,
   onViewHistory,
-  onUpdateStatus
+  onUpdateStatus,
+  onGenerateAcceptanceLetter,
+  onGenerateFinanceReceipt
 }: ApplicationDetailModalProps) {
+  const [isGeneratingAcceptance, setIsGeneratingAcceptance] = useState(false)
+  const [isGeneratingFinanceReceipt, setIsGeneratingFinanceReceipt] = useState(false)
+
+  useEffect(() => {
+    setIsGeneratingAcceptance(false)
+    setIsGeneratingFinanceReceipt(false)
+  }, [application?.id, show])
+
   if (!show || !application) return null
+
+  const handleGenerateAcceptance = async () => {
+    try {
+      setIsGeneratingAcceptance(true)
+      await onGenerateAcceptanceLetter()
+    } catch (error) {
+      console.error('Failed to generate acceptance letter:', error)
+    } finally {
+      setIsGeneratingAcceptance(false)
+    }
+  }
+
+  const handleGenerateFinanceReceipt = async () => {
+    try {
+      setIsGeneratingFinanceReceipt(true)
+      await onGenerateFinanceReceipt()
+    } catch (error) {
+      console.error('Failed to generate finance receipt:', error)
+    } finally {
+      setIsGeneratingFinanceReceipt(false)
+    }
+  }
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
@@ -300,6 +334,24 @@ export function ApplicationDetailModal({
                 className="text-red-600 border-red-300 hover:bg-red-50"
               >
                 Reject
+              </Button>
+            </>
+          )}
+          {application.status === 'approved' && (
+            <>
+              <Button
+                variant="outline"
+                loading={isGeneratingAcceptance}
+                onClick={() => { void handleGenerateAcceptance() }}
+              >
+                Generate Acceptance Letter
+              </Button>
+              <Button
+                variant="outline"
+                loading={isGeneratingFinanceReceipt}
+                onClick={() => { void handleGenerateFinanceReceipt() }}
+              >
+                Generate Finance Receipt
               </Button>
             </>
           )}

--- a/src/services/documents.ts
+++ b/src/services/documents.ts
@@ -5,5 +5,17 @@ export const documentService = {
     apiClient.request('/api/documents/upload', {
       method: 'POST',
       body: JSON.stringify(data)
+    }),
+
+  generateAcceptanceLetter: (applicationId: string) =>
+    apiClient.request('/api/documents/acceptance-letter', {
+      method: 'POST',
+      body: JSON.stringify({ applicationId })
+    }),
+
+  generateFinanceReceipt: (applicationId: string) =>
+    apiClient.request('/api/documents/finance-receipt', {
+      method: 'POST',
+      body: JSON.stringify({ applicationId })
     })
 }


### PR DESCRIPTION
## Summary
- extend the application detail modal with callbacks and UI controls to generate acceptance letters and finance receipts when an application is approved
- add document service helpers for triggering acceptance letter and finance receipt generation APIs
- wire the admin applications page to invoke the new helpers, surface toast feedback, and refresh the application documents list after generation

## Testing
- `npm run lint` *(fails: existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4db153d083328a9e3ead137b23c0