### PR TITLE
Add system generated flag to application documents

### DIFF
--- a/api/applications/[id].js
+++ b/api/applications/[id].js
@@ -44,7 +44,7 @@ async function handleGet(req, res, { user, isAdmin }, id) {
 
     const selectClauses = ['*']
     if (include.has('documents')) {
-      selectClauses.push(`documents:${DOCUMENTS_TABLE}(id, document_type, document_name, file_url, file_size, mime_type, verification_status, verified_by, verified_at, verification_notes)`)
+      selectClauses.push(`documents:${DOCUMENTS_TABLE}(id, document_type, document_name, file_url, file_size, mime_type, system_generated, verification_status, verified_by, verified_at, verification_notes)`)
     }
     if (include.has('grades')) {
       selectClauses.push('grades:application_grades(subject_id, grade, subject:grade12_subjects(name))')
@@ -89,7 +89,8 @@ async function handleGet(req, res, { user, isAdmin }, id) {
           document_type: 'result_slip',
           document_name: 'Grade 12 Result Slip',
           file_url: application.result_slip_url,
-          verification_status: 'pending'
+          verification_status: 'pending',
+          system_generated: false
         })
       }
       if (application.extra_kyc_url && !existingTypes.has('extra_kyc')) {
@@ -98,7 +99,8 @@ async function handleGet(req, res, { user, isAdmin }, id) {
           document_type: 'extra_kyc',
           document_name: 'Additional KYC Document',
           file_url: application.extra_kyc_url,
-          verification_status: 'pending'
+          verification_status: 'pending',
+          system_generated: false
         })
       }
       if (application.pop_url && !existingTypes.has('proof_of_payment')) {
@@ -107,7 +109,8 @@ async function handleGet(req, res, { user, isAdmin }, id) {
           document_type: 'proof_of_payment',
           document_name: 'Proof of Payment',
           file_url: application.pop_url,
-          verification_status: 'pending'
+          verification_status: 'pending',
+          system_generated: false
         })
       }
     }

--- a/api/documents/upload.js
+++ b/api/documents/upload.js
@@ -51,6 +51,7 @@ module.exports = async function handler(req, res) {
         document_type: documentType,
         document_name: fileName,
         file_url: uploadData.path,
+        system_generated: false,
         verification_status: 'pending'
       })
       .select()

--- a/sql/add_system_generated_to_application_documents.sql
+++ b/sql/add_system_generated_to_application_documents.sql
@@ -1,0 +1,3 @@
+-- Ensure the application_documents table has a system_generated flag
+ALTER TABLE application_documents
+  ADD COLUMN IF NOT EXISTS system_generated BOOLEAN NOT NULL DEFAULT FALSE;

--- a/sql/apply-database-fixes.sql
+++ b/sql/apply-database-fixes.sql
@@ -86,6 +86,7 @@ CREATE TABLE IF NOT EXISTS application_documents (
   document_type VARCHAR(50) NOT NULL,
   document_name VARCHAR(255) NOT NULL,
   file_url VARCHAR(500) NOT NULL,
+  system_generated BOOLEAN NOT NULL DEFAULT FALSE,
   verification_status VARCHAR(20) DEFAULT 'pending' CHECK (verification_status IN ('pending', 'verified', 'rejected')),
   verified_by UUID REFERENCES auth.users(id),
   verified_at TIMESTAMPTZ,

--- a/sql/fix_admin_rls_policies.sql
+++ b/sql/fix_admin_rls_policies.sql
@@ -103,6 +103,7 @@ CREATE TABLE IF NOT EXISTS application_documents (
   file_url VARCHAR(500) NOT NULL,
   file_size INTEGER,
   mime_type VARCHAR(100),
+  system_generated BOOLEAN NOT NULL DEFAULT FALSE,
   verification_status VARCHAR(20) DEFAULT 'pending' CHECK (verification_status IN ('pending', 'verified', 'rejected')),
   verified_by UUID REFERENCES auth.users(id),
   verified_at TIMESTAMPTZ,

--- a/src/hooks/admin/useApplicationDocuments.ts
+++ b/src/hooks/admin/useApplicationDocuments.ts
@@ -6,6 +6,7 @@ interface DocumentInfo {
   document_type: string
   document_name: string
   file_url: string
+  system_generated: boolean
   verification_status: string
   verified_by?: string
   verified_at?: string

--- a/src/lib/applicationSlip.ts
+++ b/src/lib/applicationSlip.ts
@@ -343,7 +343,8 @@ export async function persistSlip(applicationNumber: string, blob: Blob): Promis
           application_id: application.id,
           document_type: 'application_slip',
           document_name: `Application Slip - ${trimmedNumber}.pdf`,
-          file_url: publicUrl || uploadData.path
+          file_url: publicUrl || uploadData.path,
+          system_generated: true
         }
 
         const { data: existingDocument, error: existingError } = await supabase

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -328,6 +328,7 @@ export interface ApplicationDocument {
   file_url: string
   file_size?: number
   mime_type?: string
+  system_generated: boolean
   verification_status: 'pending' | 'verified' | 'rejected'
   verified_by?: string
   verified_at?: string


### PR DESCRIPTION
## Summary
- add a schema update that introduces a `system_generated` flag for `application_documents`
- propagate the new column through document upload, retrieval, and type definitions
- mark generated artifacts as system-produced while leaving manual uploads as user-provided

## Testing
- npm run lint *(fails: existing lint errors and warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc59a23350833280774ce33d89ae72