### PR TITLE
Add document templates module and admin export tooling

### DIFF
--- a/src/components/admin/ReportsGenerator.tsx
+++ b/src/components/admin/ReportsGenerator.tsx
@@ -1,9 +1,24 @@
-import React, { useState } from 'react'
+import React, { ChangeEvent, useEffect, useMemo, useState } from 'react'
 import { Button } from '@/components/ui/Button'
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 import { supabase } from '@/lib/supabase'
-import { Download, FileText, Calendar, FileDown, FileSpreadsheet } from 'lucide-react'
+import {
+  Download,
+  FileText,
+  Calendar,
+  FileDown,
+  FileSpreadsheet,
+  FileCode,
+  ClipboardCopy
+} from 'lucide-react'
 import { exportReport, ReportFormat } from '@/lib/reportExports'
+import {
+  DOCUMENT_TEMPLATE_DEFINITIONS,
+  DocumentTemplateContext,
+  DocumentTemplateId,
+  renderTemplateById
+} from '@/lib/documentTemplates'
+import { useRoleQuery } from '@/hooks/auth/useRoleQuery'
 
 interface ReportConfig {
   type: 'daily' | 'weekly' | 'monthly' | 'regulatory'
@@ -15,8 +30,108 @@ interface ReportConfig {
   format: ReportFormat
 }
 
+type DocumentFormState = {
+  studentName: string
+  studentPreferredName: string
+  studentEmail: string
+  studentPhone: string
+  programName: string
+  intake: string
+  startDate: string
+  responseDeadline: string
+  orientationDate: string
+  referenceNumber: string
+  decisionDate: string
+  interviewDate: string
+  interviewTime: string
+  interviewLocation: string
+  interviewMode: string
+  feedbackSummary: string
+  feedbackStrengths: string
+  feedbackImprovements: string
+  feedbackRecommendation: string
+  staffName: string
+  staffTitle: string
+  staffDepartment: string
+  staffEmail: string
+  staffPhone: string
+  paymentAmountDue: string
+  paymentAmountPaid: string
+  paymentBalance: string
+  paymentDueDate: string
+  paymentReference: string
+  paymentLastPaymentDate: string
+  paymentBreakdown: string
+}
+
+const initialDocumentForm: DocumentFormState = {
+  studentName: '',
+  studentPreferredName: '',
+  studentEmail: '',
+  studentPhone: '',
+  programName: '',
+  intake: '',
+  startDate: '',
+  responseDeadline: '',
+  orientationDate: '',
+  referenceNumber: '',
+  decisionDate: '',
+  interviewDate: '',
+  interviewTime: '',
+  interviewLocation: '',
+  interviewMode: '',
+  feedbackSummary: '',
+  feedbackStrengths: '',
+  feedbackImprovements: '',
+  feedbackRecommendation: '',
+  staffName: '',
+  staffTitle: '',
+  staffDepartment: '',
+  staffEmail: '',
+  staffPhone: '',
+  paymentAmountDue: '',
+  paymentAmountPaid: '',
+  paymentBalance: '',
+  paymentDueDate: '',
+  paymentReference: '',
+  paymentLastPaymentDate: '',
+  paymentBreakdown: ''
+}
+
+const parseNumberInput = (value: string) => {
+  const normalized = value.replace(/[^0-9.-]/g, '').trim()
+  if (!normalized) return undefined
+  const parsed = Number.parseFloat(normalized)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+const parseListInput = (value: string) =>
+  value
+    .split(/\r?\n/)
+    .map(entry => entry.trim())
+    .filter(Boolean)
+
+const parseBreakdownInput = (value: string) =>
+  value
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(line => {
+      const [labelPart, amountPart] = line.split(/[:|\-–—]/, 2)
+      if (!labelPart || !amountPart) return null
+      const amountValue = amountPart.replace(/[^0-9.-]/g, '').trim()
+      const parsed = Number.parseFloat(amountValue)
+      if (!Number.isFinite(parsed)) return null
+      return {
+        label: labelPart.trim(),
+        amount: parsed
+      }
+    })
+    .filter((entry): entry is { label: string; amount: number } => Boolean(entry && entry.label))
+
 export function ReportsGenerator() {
   const [loading, setLoading] = useState(false)
+  const { isAdmin } = useRoleQuery()
   const [config, setConfig] = useState<ReportConfig>({
     type: 'monthly',
     startDate: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
@@ -26,6 +141,142 @@ export function ReportsGenerator() {
     includeEligibility: true,
     format: 'pdf'
   })
+  const [selectedTemplate, setSelectedTemplate] = useState<DocumentTemplateId>('offerLetter')
+  const [documentForm, setDocumentForm] = useState<DocumentFormState>(initialDocumentForm)
+  const [documentGenerating, setDocumentGenerating] = useState(false)
+  const [documentPreview, setDocumentPreview] = useState<{
+    templateId: DocumentTemplateId
+    html: string
+    text: string
+  } | null>(null)
+  const [previewMode, setPreviewMode] = useState<'html' | 'text'>('html')
+
+  const templateOptions = useMemo(
+    () => Object.values(DOCUMENT_TEMPLATE_DEFINITIONS),
+    []
+  )
+
+  const selectedTemplateDefinition = useMemo(
+    () => DOCUMENT_TEMPLATE_DEFINITIONS[selectedTemplate],
+    [selectedTemplate]
+  )
+
+  useEffect(() => {
+    setDocumentPreview(null)
+    setPreviewMode('html')
+  }, [selectedTemplate])
+
+  const handleDocumentFieldChange = (field: keyof DocumentFormState) => (
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { value } = event.target
+    setDocumentForm(prev => ({ ...prev, [field]: value }))
+  }
+
+  const buildDocumentContext = (): DocumentTemplateContext => {
+    const strengths = parseListInput(documentForm.feedbackStrengths)
+    const improvements = parseListInput(documentForm.feedbackImprovements)
+    const breakdown = parseBreakdownInput(documentForm.paymentBreakdown)
+
+    const context: DocumentTemplateContext = {
+      student: {
+        fullName: documentForm.studentName || undefined,
+        preferredName: documentForm.studentPreferredName || undefined,
+        email: documentForm.studentEmail || undefined,
+        phone: documentForm.studentPhone || undefined,
+        program: documentForm.programName || undefined
+      },
+      application: {
+        programName: documentForm.programName || undefined,
+        intake: documentForm.intake || undefined,
+        startDate: documentForm.startDate || undefined,
+        responseDeadline: documentForm.responseDeadline || undefined,
+        orientationDate: documentForm.orientationDate || undefined,
+        interviewDate: documentForm.interviewDate || undefined,
+        interviewTime: documentForm.interviewTime || undefined,
+        interviewLocation: documentForm.interviewLocation || undefined,
+        interviewMode: documentForm.interviewMode || undefined,
+        decisionDate: documentForm.decisionDate || undefined,
+        referenceNumber: documentForm.referenceNumber || undefined
+      },
+      staff: {
+        fullName: documentForm.staffName || undefined,
+        title: documentForm.staffTitle || undefined,
+        department: documentForm.staffDepartment || undefined,
+        email: documentForm.staffEmail || undefined,
+        phone: documentForm.staffPhone || undefined
+      },
+      feedback: {
+        summary: documentForm.feedbackSummary || undefined,
+        strengths: strengths.length ? strengths : undefined,
+        improvements: improvements.length ? improvements : undefined,
+        recommendation: documentForm.feedbackRecommendation || undefined
+      },
+      payment: {
+        amountDue: parseNumberInput(documentForm.paymentAmountDue),
+        amountPaid: parseNumberInput(documentForm.paymentAmountPaid),
+        balance: parseNumberInput(documentForm.paymentBalance),
+        dueDate: documentForm.paymentDueDate || undefined,
+        reference: documentForm.paymentReference || undefined,
+        lastPaymentDate: documentForm.paymentLastPaymentDate || undefined,
+        breakdown: breakdown.length ? breakdown : undefined
+      }
+    }
+
+    return context
+  }
+
+  const downloadPdfDocument = (blob: Blob, fileName: string) => {
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = fileName
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    URL.revokeObjectURL(url)
+  }
+
+  const handleDocumentAction = async (
+    templateId: DocumentTemplateId,
+    action: 'pdf' | 'html' | 'text'
+  ) => {
+    try {
+      setDocumentGenerating(true)
+      const context = buildDocumentContext()
+      const result = await renderTemplateById(templateId, context)
+
+      setDocumentPreview({
+        templateId,
+        html: result.html,
+        text: result.text
+      })
+
+      if (action === 'pdf') {
+        const blob = result.pdf.blob ?? new Blob([result.pdf.bytes], { type: 'application/pdf' })
+        downloadPdfDocument(blob, result.pdf.fileName)
+        alert('Document generated and downloaded successfully!')
+        setPreviewMode('html')
+        return
+      }
+
+      const content = action === 'html' ? result.html : result.text
+      setPreviewMode(action === 'html' ? 'html' : 'text')
+
+      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(content)
+        alert(action === 'html' ? 'Template HTML copied to clipboard.' : 'Template text copied to clipboard.')
+      } else {
+        alert('Preview updated below. Copy the contents manually.')
+      }
+    } catch (error) {
+      console.error('Failed to generate document template:', error)
+      const message = error instanceof Error ? error.message : 'Failed to generate document template.'
+      alert(message)
+    } finally {
+      setDocumentGenerating(false)
+    }
+  }
 
   const generateReport = async () => {
     try {
@@ -261,6 +512,558 @@ export function ReportsGenerator() {
             )}
           </Button>
         </div>
+
+        {isAdmin ? (
+          <div className="pt-8 border-t border-gray-200 space-y-6">
+            <div>
+              <h4 className="text-lg font-semibold text-gray-900 flex items-center space-x-2">
+                <FileText className="h-4 w-4 text-blue-500" />
+                <span>Official Document Templates</span>
+              </h4>
+              <p className="text-sm text-gray-600">
+                Generate structured admissions, interview and finance communications using the details provided below.
+              </p>
+            </div>
+
+            <div className="grid gap-6 lg:grid-cols-2">
+              <div className="space-y-4">
+                <div>
+                  <label
+                    className="block text-sm font-medium text-gray-700 mb-1"
+                    htmlFor="document-template-select"
+                  >
+                    Template
+                  </label>
+                  <select
+                    id="document-template-select"
+                    value={selectedTemplate}
+                    onChange={(event) => setSelectedTemplate(event.target.value as DocumentTemplateId)}
+                    className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  >
+                    {templateOptions.map(option => (
+                      <option key={option.id} value={option.id}>
+                        {option.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
+                  <h5 className="text-sm font-semibold text-gray-700">Required placeholders</h5>
+                  <ul className="mt-2 space-y-2 text-xs text-gray-600">
+                    {selectedTemplateDefinition.tokens.map(token => (
+                      <li key={token.token} className="border-b border-gray-200 pb-2 last:border-b-0 last:pb-0">
+                        <div className="font-mono text-[11px] text-gray-500">{`{{${token.token}}}`}</div>
+                        <div className="text-gray-700">
+                          {token.label}
+                          {token.required === false && <span className="text-gray-500"> (optional)</span>}
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                  <Button
+                    onClick={() => handleDocumentAction(selectedTemplate, 'pdf')}
+                    disabled={documentGenerating}
+                    className="w-full"
+                  >
+                    <Download className="h-4 w-4 mr-2" />
+                    Download PDF
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => handleDocumentAction(selectedTemplate, 'html')}
+                    disabled={documentGenerating}
+                    className="w-full"
+                  >
+                    <FileCode className="h-4 w-4 mr-2" />
+                    Copy HTML
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => handleDocumentAction(selectedTemplate, 'text')}
+                    disabled={documentGenerating}
+                    className="w-full"
+                  >
+                    <ClipboardCopy className="h-4 w-4 mr-2" />
+                    Copy Text
+                  </Button>
+                </div>
+                {documentGenerating && (
+                  <div className="flex items-center text-sm text-gray-500">
+                    <LoadingSpinner size="sm" className="mr-2" />
+                    Preparing document…
+                  </div>
+                )}
+                <p className="text-xs text-gray-500">
+                  Fill in the relevant sections below. Optional placeholders will be skipped automatically when left blank.
+                </p>
+              </div>
+            </div>
+
+            <div className="grid gap-6 md:grid-cols-2">
+              <div className="space-y-4">
+                <div>
+                  <h5 className="text-sm font-semibold text-gray-700 mb-2">Student & Programme</h5>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-student-name">
+                        Student full name
+                      </label>
+                      <input
+                        id="document-student-name"
+                        type="text"
+                        value={documentForm.studentName}
+                        onChange={handleDocumentFieldChange('studentName')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder="Jane Doe"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-student-email">
+                        Student email
+                      </label>
+                      <input
+                        id="document-student-email"
+                        type="email"
+                        value={documentForm.studentEmail}
+                        onChange={handleDocumentFieldChange('studentEmail')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder="student@example.com"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-student-phone">
+                        Student phone (optional)
+                      </label>
+                      <input
+                        id="document-student-phone"
+                        type="text"
+                        value={documentForm.studentPhone}
+                        onChange={handleDocumentFieldChange('studentPhone')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder="+260 700 000 000"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-program-name">
+                        Programme
+                      </label>
+                      <input
+                        id="document-program-name"
+                        type="text"
+                        value={documentForm.programName}
+                        onChange={handleDocumentFieldChange('programName')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder="Diploma in Accounting"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-intake">
+                        Intake period
+                      </label>
+                      <input
+                        id="document-intake"
+                        type="text"
+                        value={documentForm.intake}
+                        onChange={handleDocumentFieldChange('intake')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder="January 2025"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-start-date">
+                        Programme start date
+                      </label>
+                      <input
+                        id="document-start-date"
+                        type="date"
+                        value={documentForm.startDate}
+                        onChange={handleDocumentFieldChange('startDate')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-response-deadline">
+                        Acceptance deadline
+                      </label>
+                      <input
+                        id="document-response-deadline"
+                        type="date"
+                        value={documentForm.responseDeadline}
+                        onChange={handleDocumentFieldChange('responseDeadline')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-orientation-date">
+                        Orientation date
+                      </label>
+                      <input
+                        id="document-orientation-date"
+                        type="date"
+                        value={documentForm.orientationDate}
+                        onChange={handleDocumentFieldChange('orientationDate')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-reference-number">
+                        Reference number
+                      </label>
+                      <input
+                        id="document-reference-number"
+                        type="text"
+                        value={documentForm.referenceNumber}
+                        onChange={handleDocumentFieldChange('referenceNumber')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder="APP-2025-001"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-decision-date">
+                        Decision date (optional)
+                      </label>
+                      <input
+                        id="document-decision-date"
+                        type="date"
+                        value={documentForm.decisionDate}
+                        onChange={handleDocumentFieldChange('decisionDate')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                <div>
+                  <h5 className="text-sm font-semibold text-gray-700 mb-2">Interview Details</h5>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-interview-date">
+                        Interview date
+                      </label>
+                      <input
+                        id="document-interview-date"
+                        type="date"
+                        value={documentForm.interviewDate}
+                        onChange={handleDocumentFieldChange('interviewDate')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-interview-time">
+                        Interview time
+                      </label>
+                      <input
+                        id="document-interview-time"
+                        type="time"
+                        value={documentForm.interviewTime}
+                        onChange={handleDocumentFieldChange('interviewTime')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-interview-mode">
+                        Interview mode
+                      </label>
+                      <input
+                        id="document-interview-mode"
+                        type="text"
+                        value={documentForm.interviewMode}
+                        onChange={handleDocumentFieldChange('interviewMode')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder="Virtual / In-person"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-interview-location">
+                        Location or link
+                      </label>
+                      <input
+                        id="document-interview-location"
+                        type="text"
+                        value={documentForm.interviewLocation}
+                        onChange={handleDocumentFieldChange('interviewLocation')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder="Admissions Centre / Zoom link"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                <div>
+                  <h5 className="text-sm font-semibold text-gray-700 mb-2">Feedback Notes</h5>
+                  <div className="space-y-3">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-feedback-summary">
+                        Summary
+                      </label>
+                      <textarea
+                        id="document-feedback-summary"
+                        value={documentForm.feedbackSummary}
+                        onChange={handleDocumentFieldChange('feedbackSummary')}
+                        rows={3}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder="Overall impression and decision rationale"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-feedback-strengths">
+                        Strengths (one per line)
+                      </label>
+                      <textarea
+                        id="document-feedback-strengths"
+                        value={documentForm.feedbackStrengths}
+                        onChange={handleDocumentFieldChange('feedbackStrengths')}
+                        rows={3}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder={"Strong leadership skills\nClear motivation"}
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-feedback-improvements">
+                        Areas for improvement (one per line)
+                      </label>
+                      <textarea
+                        id="document-feedback-improvements"
+                        value={documentForm.feedbackImprovements}
+                        onChange={handleDocumentFieldChange('feedbackImprovements')}
+                        rows={3}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder={"Strengthen quantitative examples\nProvide additional references"}
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-feedback-recommendation">
+                        Recommended next steps (optional)
+                      </label>
+                      <textarea
+                        id="document-feedback-recommendation"
+                        value={documentForm.feedbackRecommendation}
+                        onChange={handleDocumentFieldChange('feedbackRecommendation')}
+                        rows={2}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder="Suggested improvements or follow-up guidance"
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                <div>
+                  <h5 className="text-sm font-semibold text-gray-700 mb-2">Payment Summary</h5>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-amount-due">
+                        Total charges (K)
+                      </label>
+                      <input
+                        id="document-amount-due"
+                        type="text"
+                        value={documentForm.paymentAmountDue}
+                        onChange={handleDocumentFieldChange('paymentAmountDue')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder="1250"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-amount-paid">
+                        Payments received (K)
+                      </label>
+                      <input
+                        id="document-amount-paid"
+                        type="text"
+                        value={documentForm.paymentAmountPaid}
+                        onChange={handleDocumentFieldChange('paymentAmountPaid')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder="800"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-balance">
+                        Outstanding balance (K)
+                      </label>
+                      <input
+                        id="document-balance"
+                        type="text"
+                        value={documentForm.paymentBalance}
+                        onChange={handleDocumentFieldChange('paymentBalance')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder="450"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-payment-due">
+                        Payment due date
+                      </label>
+                      <input
+                        id="document-payment-due"
+                        type="date"
+                        value={documentForm.paymentDueDate}
+                        onChange={handleDocumentFieldChange('paymentDueDate')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-payment-reference">
+                        Payment reference
+                      </label>
+                      <input
+                        id="document-payment-reference"
+                        type="text"
+                        value={documentForm.paymentReference}
+                        onChange={handleDocumentFieldChange('paymentReference')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder="INV-2025-04"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-payment-last">
+                        Last payment date (optional)
+                      </label>
+                      <input
+                        id="document-payment-last"
+                        type="date"
+                        value={documentForm.paymentLastPaymentDate}
+                        onChange={handleDocumentFieldChange('paymentLastPaymentDate')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      />
+                    </div>
+                  </div>
+                  <div className="mt-3">
+                    <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-payment-breakdown">
+                      Itemised breakdown (one item per line e.g. Tuition - 950)
+                    </label>
+                    <textarea
+                      id="document-payment-breakdown"
+                      value={documentForm.paymentBreakdown}
+                      onChange={handleDocumentFieldChange('paymentBreakdown')}
+                      rows={3}
+                      className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      placeholder={"Tuition - 950\nLibrary Fee - 50"}
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <h5 className="text-sm font-semibold text-gray-700 mb-2">Staff Contact</h5>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-staff-name">
+                        Staff name
+                      </label>
+                      <input
+                        id="document-staff-name"
+                        type="text"
+                        value={documentForm.staffName}
+                        onChange={handleDocumentFieldChange('staffName')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder="Dr. Chanda Mwila"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-staff-title">
+                        Title / role
+                      </label>
+                      <input
+                        id="document-staff-title"
+                        type="text"
+                        value={documentForm.staffTitle}
+                        onChange={handleDocumentFieldChange('staffTitle')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder="Admissions Director"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-staff-department">
+                        Department (optional)
+                      </label>
+                      <input
+                        id="document-staff-department"
+                        type="text"
+                        value={documentForm.staffDepartment}
+                        onChange={handleDocumentFieldChange('staffDepartment')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder="Admissions Office"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-staff-email">
+                        Contact email
+                      </label>
+                      <input
+                        id="document-staff-email"
+                        type="email"
+                        value={documentForm.staffEmail}
+                        onChange={handleDocumentFieldChange('staffEmail')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder="admissions@example.com"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="document-staff-phone">
+                        Contact phone (optional)
+                      </label>
+                      <input
+                        id="document-staff-phone"
+                        type="text"
+                        value={documentForm.staffPhone}
+                        onChange={handleDocumentFieldChange('staffPhone')}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder="+260 900 000 000"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {documentPreview && (
+              <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-semibold text-gray-700">
+                      {DOCUMENT_TEMPLATE_DEFINITIONS[documentPreview.templateId].name} preview
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      Showing {previewMode === 'html' ? 'HTML markup' : 'plain text'} output ready for review.
+                    </p>
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <Button
+                      size="sm"
+                      variant={previewMode === 'html' ? 'secondary' : 'outline'}
+                      onClick={() => setPreviewMode('html')}
+                    >
+                      HTML
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant={previewMode === 'text' ? 'secondary' : 'outline'}
+                      onClick={() => setPreviewMode('text')}
+                    >
+                      Text
+                    </Button>
+                  </div>
+                </div>
+                <pre className="mt-3 max-h-64 overflow-y-auto whitespace-pre-wrap text-xs bg-white border border-gray-200 rounded-md p-3">
+                  {previewMode === 'html' ? documentPreview.html : documentPreview.text}
+                </pre>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="pt-8 border-t border-gray-200">
+            <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 text-sm text-yellow-800">
+              Document templates are available to authorised staff members.
+            </div>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/lib/documentTemplates.ts
+++ b/src/lib/documentTemplates.ts
@@ -1,0 +1,845 @@
+import { PDFDocument, StandardFonts } from 'pdf-lib'
+
+export type DocumentTemplateId =
+  | 'offerLetter'
+  | 'interviewInvitation'
+  | 'rejectionFeedback'
+  | 'paymentBalanceStatement'
+
+export interface DocumentTemplateToken {
+  token: string
+  label: string
+  required?: boolean
+}
+
+export interface DocumentTemplateSection {
+  heading?: string
+  paragraphs?: string[]
+  bullets?: string[]
+  bulletTokens?: Array<{
+    token: string
+    itemTemplate?: string
+  }>
+}
+
+export interface DocumentTemplateDefinition {
+  id: DocumentTemplateId
+  name: string
+  description: string
+  tokens: DocumentTemplateToken[]
+  sections: DocumentTemplateSection[]
+}
+
+export interface DocumentTemplateContext {
+  student?: {
+    fullName?: string
+    preferredName?: string
+    email?: string
+    phone?: string
+    program?: string
+    studentId?: string
+  }
+  application?: {
+    programName?: string
+    intake?: string
+    startDate?: string | Date
+    responseDeadline?: string | Date
+    orientationDate?: string | Date
+    interviewDate?: string | Date
+    interviewTime?: string
+    interviewLocation?: string
+    interviewMode?: string
+    interviewers?: string[]
+    decisionDate?: string | Date
+    referenceNumber?: string
+    status?: string
+  }
+  staff?: {
+    fullName?: string
+    title?: string
+    department?: string
+    email?: string
+    phone?: string
+  }
+  feedback?: {
+    summary?: string
+    strengths?: string[]
+    improvements?: string[]
+    recommendation?: string
+  }
+  payment?: {
+    amountDue?: number
+    amountPaid?: number
+    balance?: number
+    dueDate?: string | Date
+    reference?: string
+    lastPaymentDate?: string | Date
+    breakdown?: Array<{ label: string; amount: number }>
+  }
+}
+
+export interface RenderedDocumentTemplate {
+  template: DocumentTemplateDefinition
+  html: string
+  text: string
+  tokens: Record<string, string>
+  pdf: {
+    bytes: Uint8Array
+    blob: Blob | null
+    fileName: string
+  }
+}
+
+export interface RenderDocumentTemplateOptions {
+  fileName?: string
+  titleOverride?: string
+}
+
+const TOKEN_REGEX = /{{\s*([^}]+)\s*}}/g
+
+const CURRENCY_TOKEN_SET = new Set([
+  'payment.amountDue',
+  'payment.amountPaid',
+  'payment.balance'
+])
+
+const DATE_LIKE_TOKEN_SET = new Set([
+  'application.startDate',
+  'application.responseDeadline',
+  'application.orientationDate',
+  'application.interviewDate',
+  'application.decisionDate',
+  'payment.dueDate',
+  'payment.lastPaymentDate'
+])
+
+const PAGE_SIZE: [number, number] = [595.28, 841.89]
+const PAGE_MARGIN = 56
+const BODY_FONT_SIZE = 11
+const HEADING_FONT_SIZE = 14
+const LINE_HEIGHT = 16
+
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+
+const isIsoLikeDateString = (value: string): boolean => {
+  if (!value) return false
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed)
+}
+
+const getValueAtPath = (source: unknown, path: string): unknown => {
+  if (!source || typeof source !== 'object') return undefined
+  const segments = path.split('.')
+  let current: any = source
+  for (const segment of segments) {
+    if (current && typeof current === 'object' && segment in current) {
+      current = current[segment as keyof typeof current]
+    } else {
+      return undefined
+    }
+  }
+  return current
+}
+
+const hasTokenValue = (context: DocumentTemplateContext, token: string): boolean => {
+  const value = getValueAtPath(context, token)
+  if (value === null || value === undefined) {
+    return false
+  }
+  if (typeof value === 'string') {
+    return value.trim().length > 0
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0
+  }
+  return true
+}
+
+const formatNumber = (value: number, token: string) => {
+  if (CURRENCY_TOKEN_SET.has(token)) {
+    return value.toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2
+    })
+  }
+  return value.toLocaleString()
+}
+
+const formatDate = (value: string | Date) => {
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return typeof value === 'string' ? value : ''
+  }
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  })
+}
+
+const formatTokenValue = (token: string, rawValue: unknown): string => {
+  if (rawValue === null || rawValue === undefined) {
+    return ''
+  }
+
+  if (Array.isArray(rawValue)) {
+    return rawValue
+      .map(item => formatTokenValue(token, item))
+      .filter(Boolean)
+      .join(', ')
+  }
+
+  if (rawValue instanceof Date) {
+    return formatDate(rawValue)
+  }
+
+  if (typeof rawValue === 'number') {
+    return formatNumber(rawValue, token)
+  }
+
+  if (typeof rawValue === 'string') {
+    const trimmed = rawValue.trim()
+    if (!trimmed) return ''
+    if (DATE_LIKE_TOKEN_SET.has(token) || isIsoLikeDateString(trimmed)) {
+      return formatDate(trimmed)
+    }
+    return trimmed
+  }
+
+  return String(rawValue)
+}
+
+const fillTemplateString = (
+  template: string,
+  context: DocumentTemplateContext,
+  formatToken?: (token: string, value: unknown) => string
+) =>
+  template.replace(TOKEN_REGEX, (_, rawToken: string) => {
+    const token = rawToken.trim()
+    const value = getValueAtPath(context, token)
+    const formatted = formatToken ? formatToken(token, value) : formatTokenValue(token, value)
+    return formatted
+  })
+
+const collectTokens = (template: DocumentTemplateDefinition, context: DocumentTemplateContext) =>
+  template.tokens.reduce<Record<string, string>>((acc, token) => {
+    const raw = getValueAtPath(context, token.token)
+    acc[token.token] = formatTokenValue(token.token, raw)
+    return acc
+  }, {})
+
+const ensureRequiredTokens = (template: DocumentTemplateDefinition, context: DocumentTemplateContext) => {
+  const missing = template.tokens
+    .filter(token => token.required !== false)
+    .filter(token => !hasTokenValue(context, token.token))
+    .map(token => token.token)
+
+  if (missing.length > 0) {
+    throw new Error(`Missing required fields: ${missing.join(', ')}`)
+  }
+}
+
+const sanitizeFileName = (value: string) =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'document'
+
+const computeDefaultFileName = (
+  template: DocumentTemplateDefinition,
+  context: DocumentTemplateContext
+) => {
+  const studentName = formatTokenValue('student.fullName', getValueAtPath(context, 'student.fullName'))
+  const base = studentName ? `${template.id}-${studentName}` : template.id
+  return `${sanitizeFileName(base)}.pdf`
+}
+
+const buildSectionText = (
+  template: DocumentTemplateDefinition,
+  context: DocumentTemplateContext
+) => {
+  const textLines: string[] = []
+
+  template.sections.forEach((section, index) => {
+    if (section.heading) {
+      textLines.push(fillTemplateString(section.heading, context))
+    }
+
+    section.paragraphs?.forEach(paragraph => {
+      textLines.push(fillTemplateString(paragraph, context))
+    })
+
+    const bulletLines: string[] = []
+    section.bullets?.forEach(bullet => {
+      const filled = fillTemplateString(bullet, context)
+      if (filled.trim()) {
+        bulletLines.push(filled)
+      }
+    })
+
+    section.bulletTokens?.forEach(definition => {
+      const rawValue = getValueAtPath(context, definition.token)
+      if (!rawValue) return
+
+      const values = Array.isArray(rawValue) ? rawValue : [rawValue]
+      const itemTemplate = definition.itemTemplate ?? '{{item}}'
+      values.forEach(item => {
+        const rendered = itemTemplate.replace(/{{\s*item(\.[^}]*)?\s*}}/g, (_, path: string) => {
+          if (!path) {
+            return formatTokenValue(definition.token, item)
+          }
+          const trimmedPath = path.slice(1)
+          const nested = getValueAtPath(item, trimmedPath)
+          return formatTokenValue(trimmedPath, nested)
+        })
+        const normalized = fillTemplateString(rendered, context)
+        if (normalized.trim()) {
+          bulletLines.push(normalized)
+        }
+      })
+    })
+
+    bulletLines.forEach(line => {
+      textLines.push(`• ${line}`)
+    })
+
+    if (index < template.sections.length - 1) {
+      textLines.push('')
+    }
+  })
+
+  return textLines
+}
+
+const buildSectionHtml = (
+  template: DocumentTemplateDefinition,
+  context: DocumentTemplateContext
+) => {
+  const parts: string[] = ['<article class="document-template">']
+
+  template.sections.forEach(section => {
+    parts.push('<section>')
+    if (section.heading) {
+      const heading = escapeHtml(fillTemplateString(section.heading, context))
+      parts.push(`<h2>${heading}</h2>`)
+    }
+
+    section.paragraphs?.forEach(paragraph => {
+      const htmlParagraph = escapeHtml(fillTemplateString(paragraph, context))
+      parts.push(`<p>${htmlParagraph}</p>`)
+    })
+
+    const bulletItems: string[] = []
+
+    section.bullets?.forEach(bullet => {
+      const filled = fillTemplateString(bullet, context)
+      if (filled.trim()) {
+        bulletItems.push(escapeHtml(filled))
+      }
+    })
+
+    section.bulletTokens?.forEach(definition => {
+      const rawValue = getValueAtPath(context, definition.token)
+      if (!rawValue) return
+      const values = Array.isArray(rawValue) ? rawValue : [rawValue]
+      const itemTemplate = definition.itemTemplate ?? '{{item}}'
+      values.forEach(item => {
+        const rendered = itemTemplate.replace(/{{\s*item(\.[^}]*)?\s*}}/g, (_, path: string) => {
+          if (!path) {
+            return formatTokenValue(definition.token, item)
+          }
+          const trimmedPath = path.slice(1)
+          const nested = getValueAtPath(item, trimmedPath)
+          return formatTokenValue(trimmedPath, nested)
+        })
+        const normalized = fillTemplateString(rendered, context)
+        if (normalized.trim()) {
+          bulletItems.push(escapeHtml(normalized))
+        }
+      })
+    })
+
+    if (bulletItems.length > 0) {
+      parts.push('<ul>')
+      bulletItems.forEach(item => {
+        parts.push(`<li>${item}</li>`)
+      })
+      parts.push('</ul>')
+    }
+
+    parts.push('</section>')
+  })
+
+  parts.push('</article>')
+  return parts.join('\n')
+}
+
+const wrapTextForPdf = (
+  text: string,
+  font: import('pdf-lib').PDFFont,
+  fontSize: number,
+  maxWidth: number
+): string[] => {
+  const words = text.split(/\s+/).filter(Boolean)
+  if (!words.length) {
+    return ['']
+  }
+
+  const lines: string[] = []
+  let currentLine = ''
+
+  const pushCurrent = () => {
+    if (currentLine) {
+      lines.push(currentLine)
+      currentLine = ''
+    }
+  }
+
+  for (const word of words) {
+    const candidate = currentLine ? `${currentLine} ${word}` : word
+    const width = font.widthOfTextAtSize(candidate, fontSize)
+    if (width <= maxWidth) {
+      currentLine = candidate
+      continue
+    }
+
+    if (currentLine) {
+      pushCurrent()
+    }
+
+    if (font.widthOfTextAtSize(word, fontSize) <= maxWidth) {
+      currentLine = word
+      continue
+    }
+
+    let chunk = ''
+    for (const char of word) {
+      const tentative = chunk ? `${chunk}${char}` : char
+      if (font.widthOfTextAtSize(tentative, fontSize) <= maxWidth) {
+        chunk = tentative
+      } else {
+        if (chunk) {
+          lines.push(chunk)
+          chunk = char
+        } else {
+          lines.push(char)
+        }
+      }
+    }
+    currentLine = chunk
+  }
+
+  pushCurrent()
+
+  if (!lines.length) {
+    lines.push('')
+  }
+
+  return lines
+}
+
+const generatePdfDocument = async (
+  title: string,
+  template: DocumentTemplateDefinition,
+  context: DocumentTemplateContext
+) => {
+  const pdfDoc = await PDFDocument.create()
+  const regularFont = await pdfDoc.embedFont(StandardFonts.Helvetica)
+  const boldFont = await pdfDoc.embedFont(StandardFonts.HelveticaBold)
+
+  const addPage = () => pdfDoc.addPage(PAGE_SIZE)
+  let page = addPage()
+  let cursorY = page.getHeight() - PAGE_MARGIN
+
+  const ensureSpace = (height: number) => {
+    if (cursorY - height < PAGE_MARGIN) {
+      page = addPage()
+      cursorY = page.getHeight() - PAGE_MARGIN
+    }
+  }
+
+  const drawParagraph = (text: string, options: { bullet?: boolean; bold?: boolean } = {}) => {
+    const font = options.bold ? boldFont : regularFont
+    const maxWidth = page.getWidth() - PAGE_MARGIN * 2
+    const prefix = options.bullet ? '• ' : ''
+    const prefixWidth = options.bullet ? font.widthOfTextAtSize(prefix, BODY_FONT_SIZE) : 0
+    const lines = wrapTextForPdf(text, font, BODY_FONT_SIZE, maxWidth - prefixWidth)
+
+    lines.forEach((line, index) => {
+      ensureSpace(LINE_HEIGHT)
+      const isFirstLine = index === 0
+      const xOffset = options.bullet && !isFirstLine ? prefixWidth : 0
+      const textToDraw = options.bullet && isFirstLine ? `${prefix}${line}` : line
+      page.drawText(textToDraw, {
+        x: PAGE_MARGIN + xOffset,
+        y: cursorY,
+        size: BODY_FONT_SIZE,
+        font
+      })
+      cursorY -= LINE_HEIGHT
+    })
+
+    cursorY -= 4
+  }
+
+  const drawHeading = (text: string) => {
+    const maxWidth = page.getWidth() - PAGE_MARGIN * 2
+    const lines = wrapTextForPdf(text, boldFont, HEADING_FONT_SIZE, maxWidth)
+    lines.forEach(line => {
+      ensureSpace(HEADING_FONT_SIZE + 4)
+      page.drawText(line, {
+        x: PAGE_MARGIN,
+        y: cursorY,
+        size: HEADING_FONT_SIZE,
+        font: boldFont
+      })
+      cursorY -= HEADING_FONT_SIZE + 6
+    })
+    cursorY -= 6
+  }
+
+  if (title) {
+    drawHeading(title)
+  }
+
+  template.sections.forEach(section => {
+    if (section.heading) {
+      drawHeading(fillTemplateString(section.heading, context))
+    }
+
+    section.paragraphs?.forEach(paragraph => {
+      const text = fillTemplateString(paragraph, context)
+      if (text.trim()) {
+        drawParagraph(text)
+      }
+    })
+
+    section.bullets?.forEach(bullet => {
+      const text = fillTemplateString(bullet, context)
+      if (text.trim()) {
+        drawParagraph(text, { bullet: true })
+      }
+    })
+
+    section.bulletTokens?.forEach(definition => {
+      const rawValue = getValueAtPath(context, definition.token)
+      if (!rawValue) return
+      const values = Array.isArray(rawValue) ? rawValue : [rawValue]
+      const itemTemplate = definition.itemTemplate ?? '{{item}}'
+      values.forEach(item => {
+        const rendered = itemTemplate.replace(/{{\s*item(\.[^}]*)?\s*}}/g, (_, path: string) => {
+          if (!path) {
+            return formatTokenValue(definition.token, item)
+          }
+          const trimmedPath = path.slice(1)
+          const nested = getValueAtPath(item, trimmedPath)
+          return formatTokenValue(trimmedPath, nested)
+        })
+        const text = fillTemplateString(rendered, context)
+        if (text.trim()) {
+          drawParagraph(text, { bullet: true })
+        }
+      })
+    })
+
+    cursorY -= 8
+  })
+
+  const bytes = await pdfDoc.save()
+  const blob = typeof Blob !== 'undefined' ? new Blob([bytes], { type: 'application/pdf' }) : null
+
+  return { bytes, blob }
+}
+
+const DOCUMENT_TEMPLATES: Record<DocumentTemplateId, DocumentTemplateDefinition> = {
+  offerLetter: {
+    id: 'offerLetter',
+    name: 'Offer Letter',
+    description: 'Formal admission offer letter including enrollment steps and response deadlines.',
+    tokens: [
+      { token: 'student.fullName', label: 'Student full name' },
+      { token: 'application.programName', label: 'Program name' },
+      { token: 'application.intake', label: 'Intake period', required: false },
+      { token: 'application.startDate', label: 'Program start date' },
+      { token: 'application.responseDeadline', label: 'Acceptance deadline' },
+      { token: 'staff.fullName', label: 'Signatory name' },
+      { token: 'staff.title', label: 'Signatory title' },
+      { token: 'staff.email', label: 'Contact email', required: false },
+      { token: 'staff.phone', label: 'Contact phone', required: false }
+    ],
+    sections: [
+      {
+        paragraphs: [
+          'Dear {{student.fullName}},',
+          'Congratulations! We are delighted to offer you admission to the {{application.programName}} programme at MIHAS.',
+          'Your academic achievements and potential stood out during our review process.'
+        ]
+      },
+      {
+        heading: 'Enrollment Details',
+        paragraphs: [
+          'Programme: {{application.programName}}',
+          'Intake: {{application.intake}}',
+          'Start Date: {{application.startDate}}',
+          'Acceptance Deadline: {{application.responseDeadline}}',
+          'Student Reference: {{application.referenceNumber}}'
+        ]
+      },
+      {
+        heading: 'Next Steps',
+        bullets: [
+          'Log in to the admissions portal to confirm your acceptance by {{application.responseDeadline}}.',
+          'Submit any outstanding documents highlighted in your application checklist.',
+          'Prepare for orientation on {{application.orientationDate}} and review your welcome pack.'
+        ]
+      },
+      {
+        paragraphs: [
+          'We are excited to support your academic journey and look forward to welcoming you to campus.',
+          'Warm regards,',
+          '{{staff.fullName}}',
+          '{{staff.title}}',
+          '{{staff.email}}',
+          '{{staff.phone}}'
+        ]
+      }
+    ]
+  },
+  interviewInvitation: {
+    id: 'interviewInvitation',
+    name: 'Interview Invitation',
+    description: 'Structured invitation outlining interview logistics and preparation guidance.',
+    tokens: [
+      { token: 'student.fullName', label: 'Student full name' },
+      { token: 'application.programName', label: 'Programme name' },
+      { token: 'application.interviewDate', label: 'Interview date' },
+      { token: 'application.interviewTime', label: 'Interview time' },
+      { token: 'application.interviewMode', label: 'Interview mode' },
+      { token: 'application.interviewLocation', label: 'Interview location' },
+      { token: 'staff.fullName', label: 'Contact name' },
+      { token: 'staff.title', label: 'Contact title' },
+      { token: 'staff.email', label: 'Contact email' },
+      { token: 'staff.phone', label: 'Contact phone', required: false }
+    ],
+    sections: [
+      {
+        paragraphs: [
+          'Dear {{student.fullName}},',
+          'Thank you for your application to the {{application.programName}} programme.',
+          'We are pleased to invite you to the next stage of the selection process.'
+        ]
+      },
+      {
+        heading: 'Interview Schedule',
+        paragraphs: [
+          'Date: {{application.interviewDate}}',
+          'Time: {{application.interviewTime}}',
+          'Mode: {{application.interviewMode}}',
+          'Location / Meeting Link: {{application.interviewLocation}}'
+        ]
+      },
+      {
+        heading: 'How to Prepare',
+        bullets: [
+          'Please log in 10 minutes before the scheduled start time.',
+          'Have your identification and any supporting documents ready.',
+          'Prepare to discuss your motivation for the {{application.programName}} programme.'
+        ]
+      },
+      {
+        paragraphs: [
+          'Kindly confirm your availability by replying to this email.',
+          'If you need to reschedule, contact {{staff.fullName}} at {{staff.email}} or {{staff.phone}}.',
+          'We look forward to meeting with you.',
+          'Best regards,',
+          '{{staff.fullName}}',
+          '{{staff.title}}'
+        ]
+      }
+    ]
+  },
+  rejectionFeedback: {
+    id: 'rejectionFeedback',
+    name: 'Rejection Feedback Summary',
+    description: 'Thoughtful summary highlighting strengths and recommended improvements.',
+    tokens: [
+      { token: 'student.fullName', label: 'Student full name' },
+      { token: 'application.programName', label: 'Programme name' },
+      { token: 'feedback.summary', label: 'Overall feedback summary' },
+      { token: 'feedback.strengths', label: 'Identified strengths' },
+      { token: 'feedback.improvements', label: 'Areas for development' },
+      { token: 'staff.fullName', label: 'Reviewer name', required: false },
+      { token: 'staff.title', label: 'Reviewer title', required: false }
+    ],
+    sections: [
+      {
+        paragraphs: [
+          'Dear {{student.fullName}},',
+          'Thank you for your interest in the {{application.programName}} programme.',
+          'After careful consideration we are unable to offer you admission this cycle.'
+        ]
+      },
+      {
+        heading: 'Overall Feedback',
+        paragraphs: ['{{feedback.summary}}']
+      },
+      {
+        heading: 'Strengths Recognised',
+        bulletTokens: [
+          {
+            token: 'feedback.strengths',
+            itemTemplate: '{{item}}'
+          }
+        ]
+      },
+      {
+        heading: 'Recommended Improvements',
+        bulletTokens: [
+          {
+            token: 'feedback.improvements',
+            itemTemplate: '{{item}}'
+          }
+        ],
+        paragraphs: ['{{feedback.recommendation}}']
+      },
+      {
+        paragraphs: [
+          'We encourage you to continue pursuing your goals and to consider reapplying in the future.',
+          'Kind regards,',
+          '{{staff.fullName}}',
+          '{{staff.title}}'
+        ]
+      }
+    ]
+  },
+  paymentBalanceStatement: {
+    id: 'paymentBalanceStatement',
+    name: 'Payment Balance Statement',
+    description: 'Finance summary with outstanding balance and itemised breakdown.',
+    tokens: [
+      { token: 'student.fullName', label: 'Student full name' },
+      { token: 'application.programName', label: 'Programme name', required: false },
+      { token: 'payment.amountDue', label: 'Total charges' },
+      { token: 'payment.amountPaid', label: 'Payments received' },
+      { token: 'payment.balance', label: 'Outstanding balance' },
+      { token: 'payment.dueDate', label: 'Payment due date' },
+      { token: 'payment.reference', label: 'Payment reference', required: false },
+      { token: 'staff.fullName', label: 'Finance contact name' },
+      { token: 'staff.title', label: 'Finance contact title' },
+      { token: 'staff.email', label: 'Finance contact email', required: false },
+      { token: 'staff.phone', label: 'Finance contact phone', required: false }
+    ],
+    sections: [
+      {
+        paragraphs: [
+          'Dear {{student.fullName}},',
+          'Please find below the latest balance summary for your {{application.programName}} student account.'
+        ]
+      },
+      {
+        heading: 'Account Summary',
+        paragraphs: [
+          'Total Charges: K{{payment.amountDue}}',
+          'Payments Received: K{{payment.amountPaid}}',
+          'Outstanding Balance: K{{payment.balance}}',
+          'Payment Due Date: {{payment.dueDate}}',
+          'Last Payment Recorded: {{payment.lastPaymentDate}}',
+          'Reference: {{payment.reference}}'
+        ]
+      },
+      {
+        heading: 'Itemised Breakdown',
+        bulletTokens: [
+          {
+            token: 'payment.breakdown',
+            itemTemplate: '{{item.label}} — K{{item.amount}}'
+          }
+        ]
+      },
+      {
+        paragraphs: [
+          'Please settle the outstanding balance by the due date to avoid interruptions to your studies.',
+          'If you have already made payment, kindly share the proof of payment with our finance office.'
+        ]
+      },
+      {
+        paragraphs: [
+          'Finance Office Contact',
+          '{{staff.fullName}}',
+          '{{staff.title}}',
+          '{{staff.email}}',
+          '{{staff.phone}}'
+        ]
+      }
+    ]
+  }
+}
+
+export const DOCUMENT_TEMPLATE_DEFINITIONS = DOCUMENT_TEMPLATES
+
+export const getDocumentTemplate = (id: DocumentTemplateId) => DOCUMENT_TEMPLATES[id]
+
+export const renderDocumentTemplate = async (
+  templateId: DocumentTemplateId,
+  context: DocumentTemplateContext,
+  options: RenderDocumentTemplateOptions = {}
+): Promise<RenderedDocumentTemplate> => {
+  const template = DOCUMENT_TEMPLATES[templateId]
+  if (!template) {
+    throw new Error(`Template ${templateId} is not defined`)
+  }
+
+  ensureRequiredTokens(template, context)
+
+  const title = options.titleOverride ?? template.name
+  const textLines = buildSectionText(template, context)
+  const text = textLines.join('\n')
+  const html = buildSectionHtml(template, context)
+  const { bytes, blob } = await generatePdfDocument(title, template, context)
+  const fileName = options.fileName ?? computeDefaultFileName(template, context)
+  const tokens = collectTokens(template, context)
+
+  return {
+    template,
+    html,
+    text,
+    tokens,
+    pdf: {
+      bytes,
+      blob,
+      fileName
+    }
+  }
+}
+
+export const renderOfferLetter = (
+  context: DocumentTemplateContext,
+  options?: RenderDocumentTemplateOptions
+) => renderDocumentTemplate('offerLetter', context, options)
+
+export const renderInterviewInvitation = (
+  context: DocumentTemplateContext,
+  options?: RenderDocumentTemplateOptions
+) => renderDocumentTemplate('interviewInvitation', context, options)
+
+export const renderRejectionFeedback = (
+  context: DocumentTemplateContext,
+  options?: RenderDocumentTemplateOptions
+) => renderDocumentTemplate('rejectionFeedback', context, options)
+
+export const renderPaymentBalanceStatement = (
+  context: DocumentTemplateContext,
+  options?: RenderDocumentTemplateOptions
+) => renderDocumentTemplate('paymentBalanceStatement', context, options)
+
+export const renderTemplateById = (
+  templateId: DocumentTemplateId,
+  context: DocumentTemplateContext,
+  options?: RenderDocumentTemplateOptions
+) => renderDocumentTemplate(templateId, context, options)

--- a/tests/components/ReportsGenerator.test.tsx
+++ b/tests/components/ReportsGenerator.test.tsx
@@ -1,0 +1,134 @@
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+const roleState = vi.hoisted(() => ({ isAdmin: true }))
+
+vi.mock('@/hooks/auth/useRoleQuery', () => ({
+  useRoleQuery: () => roleState
+}))
+
+vi.mock('@/components/ui/Button', () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  )
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      gte: vi.fn().mockReturnThis(),
+      lte: vi.fn().mockResolvedValue({ data: [], error: null })
+    }))
+  }
+}))
+
+vi.mock('@/lib/documentTemplates', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/documentTemplates')>('@/lib/documentTemplates')
+  return {
+    ...actual,
+    renderTemplateById: vi.fn()
+  }
+})
+
+import { ReportsGenerator } from '@/components/admin/ReportsGenerator'
+import { DOCUMENT_TEMPLATE_DEFINITIONS, renderTemplateById } from '@/lib/documentTemplates'
+
+const renderTemplateByIdMock = vi.mocked(renderTemplateById)
+
+const originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard')
+
+beforeEach(() => {
+  roleState.isAdmin = true
+  renderTemplateByIdMock.mockReset()
+})
+
+afterEach(() => {
+  if (originalClipboard) {
+    Object.defineProperty(navigator, 'clipboard', originalClipboard)
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (navigator as any).clipboard
+  }
+})
+
+describe('<ReportsGenerator />', () => {
+  it('hides document templates for non-admin users', () => {
+    roleState.isAdmin = false
+
+    render(<ReportsGenerator />)
+
+    expect(screen.getByText('Generate Reports')).toBeTruthy()
+    expect(screen.getByText('Document templates are available to authorised staff members.')).toBeTruthy()
+    expect(screen.queryByText('Official Document Templates')).toBeNull()
+  })
+
+    it('allows admins to copy generated text templates and preview the output', async () => {
+      roleState.isAdmin = true
+
+    renderTemplateByIdMock.mockResolvedValue({
+      template: DOCUMENT_TEMPLATE_DEFINITIONS.offerLetter,
+      html: '<p>Sample HTML Preview</p>',
+      text: 'Sample Text Preview',
+      tokens: {
+        'student.fullName': 'Jane Doe'
+      },
+      pdf: {
+        bytes: new Uint8Array([1, 2, 3]),
+        blob: null,
+        fileName: 'offerletter-jane-doe.pdf'
+      }
+    })
+
+    const clipboardMock = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: clipboardMock },
+      configurable: true
+    })
+
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {})
+
+    render(<ReportsGenerator />)
+
+    fireEvent.change(screen.getByLabelText('Student full name'), { target: { value: 'Jane Doe' } })
+    fireEvent.change(screen.getByLabelText('Programme'), { target: { value: 'Diploma in Nursing' } })
+    fireEvent.change(screen.getByLabelText('Programme start date'), { target: { value: '2025-01-10' } })
+    fireEvent.change(screen.getByLabelText('Acceptance deadline'), { target: { value: '2024-12-15' } })
+    fireEvent.change(screen.getByLabelText('Staff name'), { target: { value: 'Dr. Alice Banda' } })
+    fireEvent.change(screen.getByLabelText('Title / role'), { target: { value: 'Admissions Director' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /Copy Text/i }))
+
+    await waitFor(() => expect(renderTemplateByIdMock).toHaveBeenCalled())
+
+    const [, context] = renderTemplateByIdMock.mock.calls[0]
+    expect(context.student?.fullName).toBe('Jane Doe')
+    expect(context.application?.programName).toBe('Diploma in Nursing')
+    expect(context.staff?.fullName).toBe('Dr. Alice Banda')
+
+      await waitFor(() => expect(clipboardMock).toHaveBeenCalledWith('Sample Text Preview'))
+      expect(await screen.findByText(/Sample Text Preview/)).toBeTruthy()
+
+      alertSpy.mockRestore()
+    })
+
+    it('surfaces validation errors when template rendering fails', async () => {
+      roleState.isAdmin = true
+
+    renderTemplateByIdMock.mockRejectedValue(new Error('Missing required fields: student.fullName'))
+
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {})
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(<ReportsGenerator />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Copy Text/i }))
+
+      await waitFor(() => expect(alertSpy).toHaveBeenCalledWith('Missing required fields: student.fullName'))
+      expect(screen.queryByText(/preview/i)).toBeNull()
+
+      alertSpy.mockRestore()
+      consoleErrorSpy.mockRestore()
+    })
+})

--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -1,0 +1,6 @@
+import { afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+afterEach(() => {
+  cleanup()
+})

--- a/tests/unit/documentTemplates.test.ts
+++ b/tests/unit/documentTemplates.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DOCUMENT_TEMPLATE_DEFINITIONS,
+  renderOfferLetter,
+  renderPaymentBalanceStatement,
+  renderTemplateById
+} from '@/lib/documentTemplates'
+
+describe('documentTemplates', () => {
+  it('renders offer letter with substituted tokens and generates a PDF', async () => {
+    const result = await renderOfferLetter({
+      student: {
+        fullName: 'Jane Doe',
+        email: 'jane.doe@example.com'
+      },
+      application: {
+        programName: 'Diploma in Nursing',
+        intake: 'January 2025',
+        startDate: '2025-01-10',
+        responseDeadline: '2024-12-15',
+        orientationDate: '2025-01-05',
+        referenceNumber: 'APP-001'
+      },
+      staff: {
+        fullName: 'Dr. Alice Banda',
+        title: 'Admissions Director',
+        email: 'admissions@example.com',
+        phone: '+260 700 000 000'
+      }
+    })
+
+    expect(result.text).not.toContain('{{')
+    expect(result.html).toContain('<article')
+    expect(result.tokens['student.fullName']).toBe('Jane Doe')
+    expect(result.tokens['application.programName']).toBe('Diploma in Nursing')
+    expect(result.pdf.bytes.length).toBeGreaterThan(0)
+    expect(result.pdf.fileName).toBe('offerletter-jane-doe.pdf')
+
+    const { PDFDocument } = await import('pdf-lib')
+    const pdfDoc = await PDFDocument.load(result.pdf.bytes)
+    expect(pdfDoc.getPageCount()).toBeGreaterThan(0)
+  })
+
+  it('throws a helpful error when required placeholders are missing', async () => {
+    await expect(renderOfferLetter({})).rejects.toThrow(/Missing required fields/)
+  })
+
+  it('handles payment breakdown lists and optional placeholders gracefully', async () => {
+    const result = await renderPaymentBalanceStatement({
+      student: {
+        fullName: 'Chipo Zulu'
+      },
+      application: {
+        programName: 'Community Health',
+        startDate: '2025-03-01',
+        responseDeadline: '2025-02-01'
+      },
+      payment: {
+        amountDue: 1250,
+        amountPaid: 800,
+        balance: 450,
+        dueDate: '2025-02-15',
+        lastPaymentDate: '2024-12-30',
+        breakdown: [
+          { label: 'Registration Fee', amount: 500 },
+          { label: 'Laboratory Deposit', amount: 750 }
+        ]
+      },
+      staff: {
+        fullName: 'Mwansa Tembo',
+        title: 'Finance Officer'
+      }
+    })
+
+    expect(result.text).toMatch(/Registration Fee/)
+    expect(result.text).toMatch(/Laboratory Deposit/)
+    expect(result.text).toMatch(/Outstanding Balance/)
+    expect(result.tokens['staff.email']).toBe('')
+    expect(result.tokens['staff.phone']).toBe('')
+    expect(result.pdf.bytes.length).toBeGreaterThan(0)
+
+    const { PDFDocument } = await import('pdf-lib')
+    const pdfDoc = await PDFDocument.load(result.pdf.bytes)
+    expect(pdfDoc.getPageCount()).toBeGreaterThan(0)
+  })
+
+  it('supports rendering templates by id', async () => {
+    const result = await renderTemplateById('interviewInvitation', {
+      student: { fullName: 'John Phiri' },
+      application: {
+        programName: 'Radiography',
+        interviewDate: '2025-01-20',
+        interviewTime: '09:00',
+        interviewMode: 'In-person',
+        interviewLocation: 'Admissions Centre'
+      },
+      staff: {
+        fullName: 'Nasilele Mweemba',
+        title: 'Admissions Coordinator',
+        email: 'coordinator@example.com'
+      }
+    }, { fileName: 'custom.pdf', titleOverride: 'Interview Invite' })
+
+    expect(result.template).toBe(DOCUMENT_TEMPLATE_DEFINITIONS.interviewInvitation)
+    expect(result.pdf.fileName).toBe('custom.pdf')
+    expect(result.text).toContain('Interview Schedule')
+    expect(result.html).toContain('Interview Schedule')
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -154,6 +154,20 @@ export default defineConfig(({ mode }) => {
         }
       } : undefined
     },
+    test: {
+      environment: 'jsdom',
+      setupFiles: './tests/setupTests.ts',
+      include: ['**/*.test.ts', '**/*.test.tsx'],
+      exclude: [
+        'tests/e2e/**',
+        'tests/**/*.spec.ts',
+        'tests/**/*.spec.tsx',
+        'tests/integration/**',
+        'tests/vite.config.test.ts',
+        'node_modules/**',
+        'dist/**'
+      ]
+    },
     server: {
       port: 5173,
       host: true


### PR DESCRIPTION
## Summary
- introduce reusable document template definitions that render HTML, text, and PDF outputs for key admissions communications
- extend the admin reports generator with secure template selection, data entry forms, and preview/download actions for authorised staff
- configure Vitest for jsdom testing and add focused unit/component tests covering template substitution, validation, and UI behaviour

## Testing
- `npx vitest run`
- `npm run type-check`
- `npm run lint` *(fails: pre-existing repository lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6893f0948332b9e2a3757349f81b