### PR TITLE
refactor: centralize secure id generation

### DIFF
--- a/src/lib/applicationNumberGenerator.ts
+++ b/src/lib/applicationNumberGenerator.ts
@@ -1,5 +1,4 @@
 // Secure application number generator with institution prefixes
-import { generateSecureId } from './security'
 
 export interface ApplicationNumberConfig {
   institution: 'MIHAS' | 'KATC'

--- a/src/lib/applicationSession.ts
+++ b/src/lib/applicationSession.ts
@@ -1,6 +1,7 @@
 import { supabase } from './supabase'
 import { ApplicationFormData } from '@/forms/applicationSchema'
-import { sanitizeForLog, safeJsonParse, generateSecureId } from './sanitize'
+import { sanitizeForLog, safeJsonParse } from './sanitize'
+import { getSecureId } from './security'
 
 export interface ApplicationDraft {
   id?: string
@@ -47,7 +48,7 @@ class ApplicationSessionManager {
   private onExpiry?: () => void
 
   constructor() {
-    this.sessionId = generateSecureId()
+    this.sessionId = getSecureId()
   }
 
   // Initialize session management

--- a/src/lib/offlineStorage.ts
+++ b/src/lib/offlineStorage.ts
@@ -1,3 +1,5 @@
+import { getSecureId } from './security'
+
 interface OfflineData {
   id: string
   type: 'application_draft' | 'document_upload' | 'form_submission'
@@ -46,7 +48,7 @@ class OfflineStorageManager {
   async store(data: Omit<OfflineData, 'id' | 'timestamp'>): Promise<string> {
     if (!this.db) throw new Error('Database not initialized')
     
-    const id = `${data.type}_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
+    const id = `${data.type}_${Date.now()}_${getSecureId()}`
     const offlineData: OfflineData = {
       ...data,
       id,

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -29,9 +29,7 @@ export function safeJsonParse<T>(json: string, fallback: T): T {
   }
 }
 
-export function generateSecureId(): string {
-  return Math.random().toString(36).substring(2) + Date.now().toString(36);
-}
+export { getSecureId, getSecureId as generateSecureId } from './security';
 
 export function sanitizeEmail(email: string | null | undefined): string {
   if (!email) return '';


### PR DESCRIPTION
## Summary
- add a shared `getSecureId` helper that prefers `crypto.randomUUID` with secure fallbacks
- re-export the helper from sanitize utilities and route session/offline storage IDs through it
- tidy up an unused import in the application number generator module

## Testing
- `npm run lint` *(fails: existing lint violations in unrelated files)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68cc7321c6888332ae9662d8f6f067c3