### PR TITLE
Restrict analytics reports to authorised roles

### DIFF
--- a/src/hooks/auth/useRoleQuery.ts
+++ b/src/hooks/auth/useRoleQuery.ts
@@ -4,6 +4,9 @@ import { User } from '@supabase/supabase-js'
 import { useAuth } from '@/contexts/AuthContext'
 import { getSupabaseClient } from '@/lib/supabase'
 import { sanitizeForLog } from '@/lib/security'
+import { isAdminRole } from '@/lib/auth/roles'
+
+export { ADMIN_ROLES, isAdminRole, isReportManagerRole, REPORT_MANAGER_ROLES } from '@/lib/auth/roles'
 
 export interface AuthUserRole {
   id: string
@@ -17,22 +20,6 @@ export interface AuthUserRole {
 export interface UseRoleQueryOptions {
   user?: User | null
   enabled?: boolean
-}
-
-export const ADMIN_ROLES = [
-  'admin',
-  'super_admin',
-  'admissions_officer',
-  'registrar',
-  'finance_officer',
-  'academic_head'
-] as const
-
-type AdminRole = typeof ADMIN_ROLES[number]
-
-export function isAdminRole(role?: string | null): role is AdminRole {
-  if (!role) return false
-  return ADMIN_ROLES.includes(role as AdminRole)
 }
 
 type RoleQueryResult = {

--- a/src/lib/auth/roles.ts
+++ b/src/lib/auth/roles.ts
@@ -1,0 +1,30 @@
+export const ADMIN_ROLES = [
+  'admin',
+  'super_admin',
+  'admissions_officer',
+  'registrar',
+  'finance_officer',
+  'academic_head'
+] as const
+
+export type AdminRole = (typeof ADMIN_ROLES)[number]
+
+export function isAdminRole(role?: string | null): role is AdminRole {
+  if (!role) return false
+  return ADMIN_ROLES.includes(role as AdminRole)
+}
+
+export const REPORT_MANAGER_ROLES = [
+  'admissions_officer',
+  'registrar',
+  'finance_officer',
+  'admin',
+  'super_admin'
+] as const
+
+export type ReportManagerRole = (typeof REPORT_MANAGER_ROLES)[number]
+
+export function isReportManagerRole(role?: string | null): role is ReportManagerRole {
+  if (!role) return false
+  return REPORT_MANAGER_ROLES.includes(role as ReportManagerRole)
+}


### PR DESCRIPTION
## Summary
- add shared admin/reporting role helpers for consistent checks
- gate the reports generator component and analytics UI behind report manager roles with helpful messaging
- enforce server-side role validation in AnalyticsService to block unauthorised create or export actions

## Testing
- npm run lint *(fails: existing lint errors across unrelated files, including React hook violations in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cc732fb988833287cf312b57080890