### PR TITLE
Refactor slip logic into reusable hook

### DIFF
--- a/src/pages/student/applicationWizard/__tests__/useApplicationSlip.test.tsx
+++ b/src/pages/student/applicationWizard/__tests__/useApplicationSlip.test.tsx
@@ -1,0 +1,324 @@
+import { renderHook, waitFor, cleanup } from '@testing-library/react'
+import { act } from 'react'
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach, afterAll } from 'vitest'
+
+import type { ApplicationSlipData } from '@/lib/applicationSlip'
+import useApplicationSlip, {
+  type SubmittedApplicationSummary,
+  type UseApplicationSlipOptions
+} from '../hooks/useApplicationSlip'
+
+type CreateSlipMock = UseApplicationSlipOptions['createApplicationSlip']
+type MockedCreateSlip = ReturnType<typeof vi.fn<CreateSlipMock>>
+
+describe('useApplicationSlip', () => {
+  beforeAll(() => {
+    ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  const now = new Date().toISOString()
+
+  const baseApplication: SubmittedApplicationSummary = {
+    applicationNumber: 'APP-123',
+    trackingCode: 'TRK-123',
+    program: 'Clinical Medicine',
+    institution: 'MIHAS',
+    intake: 'January 2025',
+    fullName: 'Test Student',
+    email: 'student@example.com',
+    phone: '260123456789',
+    status: 'submitted',
+    paymentStatus: 'pending_review',
+    submittedAt: now,
+    updatedAt: now
+  }
+
+  const basePayload: ApplicationSlipData = {
+    public_tracking_code: 'TRK-123',
+    application_number: 'APP-123',
+    status: 'submitted',
+    payment_status: 'pending_review',
+    submitted_at: now,
+    updated_at: now,
+    program_name: 'Clinical Medicine',
+    intake_name: 'January 2025',
+    institution: 'MIHAS',
+    full_name: 'Test Student',
+    email: 'student@example.com',
+    phone: '260123456789',
+    admin_feedback: null,
+    admin_feedback_date: null
+  }
+
+  const originalCreateObjectURL = (URL as unknown as { createObjectURL?: (value: Blob) => string }).createObjectURL
+  const originalRevokeObjectURL = (URL as unknown as { revokeObjectURL?: (value: string) => void }).revokeObjectURL
+  const originalPrompt = window.prompt
+  const originalFetch = global.fetch
+
+  const createObjectURLMock = vi.fn(() => 'blob:mock-url')
+  const revokeObjectURLMock = vi.fn()
+
+  const createToast = () => ({
+    showError: vi.fn(),
+    showInfo: vi.fn(),
+    showSuccess: vi.fn(),
+    showWarning: vi.fn()
+  })
+
+  beforeEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      writable: true,
+      value: createObjectURLMock
+    })
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      writable: true,
+      value: revokeObjectURLMock
+    })
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    createObjectURLMock.mockClear()
+    revokeObjectURLMock.mockClear()
+    if (originalFetch) {
+      global.fetch = originalFetch
+    } else {
+      // @ts-expect-error - allow removing fetch mock when not defined originally
+      delete global.fetch
+    }
+    window.prompt = originalPrompt
+  })
+
+  afterAll(() => {
+    if (originalCreateObjectURL) {
+      Object.defineProperty(URL, 'createObjectURL', {
+        configurable: true,
+        writable: true,
+        value: originalCreateObjectURL
+      })
+    } else {
+      // @ts-expect-error - clean up mocked property when undefined originally
+      delete URL.createObjectURL
+    }
+
+    if (originalRevokeObjectURL) {
+      Object.defineProperty(URL, 'revokeObjectURL', {
+        configurable: true,
+        writable: true,
+        value: originalRevokeObjectURL
+      })
+    } else {
+      // @ts-expect-error - clean up mocked property when undefined originally
+      delete URL.revokeObjectURL
+    }
+
+    window.prompt = originalPrompt
+    if (originalFetch) {
+      global.fetch = originalFetch
+    }
+  })
+
+  const createDefaultSlipMock = (): MockedCreateSlip =>
+    vi.fn<CreateSlipMock>().mockResolvedValue({
+      blob: new Blob(['test'], { type: 'application/pdf' }),
+      publicUrl: 'https://example.com/slip.pdf'
+    })
+
+  const renderUseApplicationSlip = (
+    override: Partial<UseApplicationSlipOptions> = {},
+    createMock?: MockedCreateSlip
+  ) => {
+    const toast = createToast()
+    const createApplicationSlipMock = createMock ?? createDefaultSlipMock()
+    const props: UseApplicationSlipOptions = {
+      submittedApplication: baseApplication,
+      slipPayload: basePayload,
+      success: false,
+      toast,
+      createApplicationSlip: createApplicationSlipMock,
+      ...override
+    }
+
+    return {
+      toast,
+      createApplicationSlipMock,
+      ...renderHook(() => useApplicationSlip(props))
+    }
+  }
+
+  it('caches generated slips for subsequent downloads', async () => {
+    const createApplicationSlipMock = vi.fn<CreateSlipMock>().mockResolvedValue({
+      blob: new Blob(['cached'], { type: 'application/pdf' }),
+      publicUrl: 'https://example.com/slip.pdf'
+    })
+
+    const { result } = renderUseApplicationSlip({}, createApplicationSlipMock)
+
+    await act(async () => {
+      await result.current.handleDownloadSlip()
+    })
+
+    await waitFor(() => {
+      expect(result.current.slipCache?.objectUrl).toBeDefined()
+    })
+
+    expect(createApplicationSlipMock).toHaveBeenCalledTimes(1)
+    expect(createObjectURLMock).toHaveBeenCalledTimes(1)
+
+    createObjectURLMock.mockClear()
+
+    await act(async () => {
+      await result.current.handleDownloadSlip()
+    })
+
+    expect(createApplicationSlipMock).toHaveBeenCalledTimes(1)
+    expect(createObjectURLMock).not.toHaveBeenCalled()
+  })
+
+  it('only persists slips when data is available and success is true', async () => {
+    const createApplicationSlipMock = vi.fn<CreateSlipMock>().mockResolvedValue({
+      blob: new Blob(['persist'], { type: 'application/pdf' }),
+      publicUrl: 'https://example.com/slip.pdf'
+    })
+
+    const { rerender } = renderHook(
+      (props: UseApplicationSlipOptions) => useApplicationSlip(props),
+      {
+        initialProps: {
+          submittedApplication: baseApplication,
+          slipPayload: null,
+          success: true,
+          toast: createToast(),
+          createApplicationSlip: createApplicationSlipMock
+        }
+      }
+    )
+
+    expect(createApplicationSlipMock).not.toHaveBeenCalled()
+
+    await act(async () => {
+      rerender({
+        submittedApplication: baseApplication,
+        slipPayload: basePayload,
+        success: true,
+        toast: createToast(),
+        createApplicationSlip: createApplicationSlipMock
+      })
+    })
+
+    await waitFor(() => {
+      expect(createApplicationSlipMock).toHaveBeenCalledTimes(1)
+    })
+
+    await act(async () => {
+      rerender({
+        submittedApplication: baseApplication,
+        slipPayload: basePayload,
+        success: true,
+        toast: createToast(),
+        createApplicationSlip: createApplicationSlipMock
+      })
+    })
+
+    await waitFor(() => {
+      expect(createApplicationSlipMock).toHaveBeenCalledTimes(1)
+    })
+
+    await act(async () => {
+      rerender({
+        submittedApplication: baseApplication,
+        slipPayload: basePayload,
+        success: false,
+        toast: createToast(),
+        createApplicationSlip: createApplicationSlipMock
+      })
+    })
+
+    await act(async () => {
+      rerender({
+        submittedApplication: baseApplication,
+        slipPayload: basePayload,
+        success: true,
+        toast: createToast(),
+        createApplicationSlip: createApplicationSlipMock
+      })
+    })
+
+    await waitFor(() => {
+      expect(createApplicationSlipMock).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('downloads persisted slips from public storage when necessary', async () => {
+    const createApplicationSlipMock = vi.fn<CreateSlipMock>().mockResolvedValue({
+      publicUrl: 'https://example.com/slip.pdf'
+    })
+
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      blob: async () => new Blob(['fetched'], { type: 'application/pdf' })
+    }))
+
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const { result } = renderUseApplicationSlip({ success: true }, createApplicationSlipMock)
+
+    await waitFor(() => {
+      expect(createApplicationSlipMock).toHaveBeenCalledTimes(1)
+    })
+
+    await waitFor(() => {
+      expect(result.current.slipCache?.publicUrl).toBe('https://example.com/slip.pdf')
+    })
+
+    createObjectURLMock.mockClear()
+
+    await act(async () => {
+      await result.current.handleDownloadSlip()
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith('https://example.com/slip.pdf')
+    expect(createApplicationSlipMock).toHaveBeenCalledTimes(1)
+    expect(createObjectURLMock).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect(result.current.slipCache?.objectUrl).toBeDefined()
+    })
+  })
+
+  it('overrides email address using prompt when emailing slips', async () => {
+    const createApplicationSlipMock = vi.fn<CreateSlipMock>().mockResolvedValue({
+      blob: new Blob(['email'], { type: 'application/pdf' }),
+      publicUrl: 'https://example.com/slip.pdf'
+    })
+    const onEmailUpdate = vi.fn()
+    const promptMock = vi.fn(() => 'override@example.com')
+    window.prompt = promptMock
+
+    const { result } = renderUseApplicationSlip(
+      {
+        submittedApplication: { ...baseApplication, email: null },
+        slipPayload: { ...basePayload, email: '' },
+        onEmailUpdate
+      },
+      createApplicationSlipMock
+    )
+
+    await act(async () => {
+      await result.current.handleEmailSlip()
+    })
+
+    expect(promptMock).toHaveBeenCalled()
+    expect(createApplicationSlipMock).toHaveBeenCalledTimes(1)
+
+    const [payload, options] = createApplicationSlipMock.mock.calls[0]
+    expect(payload.email).toBe('override@example.com')
+    expect(options?.sendEmail).toBe(true)
+    expect(onEmailUpdate).toHaveBeenCalledWith('override@example.com')
+  })
+})

--- a/src/pages/student/applicationWizard/hooks/useApplicationSlip.ts
+++ b/src/pages/student/applicationWizard/hooks/useApplicationSlip.ts
@@ -1,0 +1,302 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import type { ApplicationSlipData } from '@/lib/applicationSlip'
+import type { SlipServiceOptions, SlipServiceResult } from '@/lib/slipService'
+
+export interface SubmittedApplicationSummary {
+  applicationNumber: string | null
+  trackingCode: string | null
+  program: string | null
+  institution: string | null
+  intake?: string | null
+  fullName?: string | null
+  email?: string | null
+  phone?: string | null
+  status?: string | null
+  paymentStatus?: string | null
+  submittedAt?: string | null
+  updatedAt?: string | null
+}
+
+export interface SlipCacheState {
+  objectUrl?: string
+  publicUrl?: string
+  path?: string
+  documentId?: string
+}
+
+export interface ToastAPI {
+  showSuccess?: (title: string, message?: string) => void
+  showError?: (title: string, message?: string) => void
+  showInfo?: (title: string, message?: string) => void
+  showWarning?: (title: string, message?: string) => void
+}
+
+export interface UseApplicationSlipOptions {
+  submittedApplication: SubmittedApplicationSummary | null
+  slipPayload: ApplicationSlipData | null
+  success: boolean
+  toast: ToastAPI
+  createApplicationSlip: (data: ApplicationSlipData, options?: SlipServiceOptions) => Promise<SlipServiceResult>
+  onEmailUpdate?: (email: string) => void
+}
+
+export interface UseApplicationSlipResult {
+  slipCache: SlipCacheState | null
+  persistingSlip: boolean
+  slipLoading: boolean
+  emailLoading: boolean
+  handleDownloadSlip: () => Promise<void>
+  handleEmailSlip: () => Promise<void>
+}
+
+export function useApplicationSlip({
+  submittedApplication,
+  slipPayload,
+  success,
+  toast,
+  createApplicationSlip,
+  onEmailUpdate
+}: UseApplicationSlipOptions): UseApplicationSlipResult {
+  const [slipCache, setSlipCache] = useState<SlipCacheState | null>(null)
+  const [slipLoading, setSlipLoading] = useState(false)
+  const [emailLoading, setEmailLoading] = useState(false)
+  const [persistingSlip, setPersistingSlip] = useState(false)
+  const hasPersistedSlipRef = useRef(false)
+
+  useEffect(() => () => {
+    if (slipCache?.objectUrl) {
+      URL.revokeObjectURL(slipCache.objectUrl)
+    }
+  }, [slipCache?.objectUrl])
+
+  useEffect(() => {
+    if (success) {
+      return
+    }
+
+    hasPersistedSlipRef.current = false
+    setSlipCache(prev => {
+      if (!prev) {
+        return prev
+      }
+
+      if (prev.objectUrl) {
+        URL.revokeObjectURL(prev.objectUrl)
+      }
+
+      return null
+    })
+  }, [success])
+
+  useEffect(() => {
+    if (!success || !slipPayload || hasPersistedSlipRef.current) {
+      return
+    }
+
+    let cancelled = false
+
+    const persist = async () => {
+      setPersistingSlip(true)
+      try {
+        const result = await createApplicationSlip(slipPayload, { toast })
+
+        if (cancelled) {
+          return
+        }
+
+        if (result.error) {
+          toast.showError?.('Slip unavailable', result.error)
+          return
+        }
+
+        setSlipCache(prev => {
+          if (prev?.objectUrl && result.blob) {
+            URL.revokeObjectURL(prev.objectUrl)
+          }
+
+          const objectUrl = result.blob ? URL.createObjectURL(result.blob) : prev?.objectUrl
+
+          return {
+            objectUrl,
+            publicUrl: result.publicUrl || prev?.publicUrl,
+            path: result.path || prev?.path,
+            documentId: result.documentId || prev?.documentId
+          }
+        })
+
+        hasPersistedSlipRef.current = true
+      } catch (error) {
+        if (!cancelled) {
+          console.error('Automatic slip persistence failed:', error)
+        }
+      } finally {
+        if (!cancelled) {
+          setPersistingSlip(false)
+        }
+      }
+    }
+
+    persist()
+
+    return () => {
+      cancelled = true
+    }
+  }, [success, slipPayload, toast, createApplicationSlip])
+
+  const triggerDownload = useCallback((url: string, filename: string) => {
+    const link = document.createElement('a')
+    link.href = url
+    link.download = filename
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+  }, [])
+
+  const handleDownloadSlip = useCallback(async () => {
+    if (!submittedApplication) {
+      toast.showError?.('Slip unavailable', 'We could not find your submitted application details.')
+      return
+    }
+
+    const identifier = submittedApplication.applicationNumber || submittedApplication.trackingCode || 'Unknown'
+    const filename = `Application-Slip-${identifier}.pdf`
+
+    if (slipCache?.objectUrl) {
+      triggerDownload(slipCache.objectUrl, filename)
+      return
+    }
+
+    if (persistingSlip && !slipCache?.publicUrl) {
+      toast.showInfo?.('Preparing slip', 'We are still preparing your application slip. Please try again shortly.')
+      return
+    }
+
+    try {
+      setSlipLoading(true)
+
+      if (slipCache?.publicUrl && !slipCache.objectUrl) {
+        const response = await fetch(slipCache.publicUrl)
+        if (!response.ok) {
+          throw new Error('Unable to download stored application slip')
+        }
+
+        const blob = await response.blob()
+        const objectUrl = URL.createObjectURL(blob)
+        setSlipCache(prev => {
+          if (prev?.objectUrl) {
+            URL.revokeObjectURL(prev.objectUrl)
+          }
+          return { ...prev, objectUrl }
+        })
+        triggerDownload(objectUrl, filename)
+        return
+      }
+
+      if (!slipPayload) {
+        toast.showError?.('Slip unavailable', 'Missing application data for slip generation.')
+        return
+      }
+
+      const result = await createApplicationSlip(slipPayload, { toast })
+
+      if (result.error) {
+        toast.showError?.('Download failed', result.error)
+        return
+      }
+
+      const objectUrl = result.blob ? URL.createObjectURL(result.blob) : undefined
+      const downloadUrl = objectUrl || result.publicUrl
+
+      if (!downloadUrl) {
+        toast.showError?.('Download failed', 'We could not prepare the application slip for download.')
+        return
+      }
+
+      setSlipCache(prev => {
+        if (prev?.objectUrl && objectUrl && prev.objectUrl !== objectUrl) {
+          URL.revokeObjectURL(prev.objectUrl)
+        }
+        return {
+          objectUrl: objectUrl || prev?.objectUrl,
+          publicUrl: result.publicUrl || prev?.publicUrl,
+          path: result.path || prev?.path,
+          documentId: result.documentId || prev?.documentId
+        }
+      })
+
+      triggerDownload(downloadUrl, filename)
+    } catch (error) {
+      console.error('Slip download failed:', error)
+      const message = error instanceof Error ? error.message : 'Unable to download slip'
+      toast.showError?.('Download failed', message)
+    } finally {
+      setSlipLoading(false)
+    }
+  }, [submittedApplication, slipCache, persistingSlip, slipPayload, toast, triggerDownload, createApplicationSlip])
+
+  const handleEmailSlip = useCallback(async () => {
+    if (!slipPayload || !submittedApplication) {
+      toast.showError?.('Slip unavailable', 'Missing application details for slip delivery.')
+      return
+    }
+
+    let emailAddress = submittedApplication.email?.trim() || slipPayload.email?.trim() || ''
+    if (!emailAddress) {
+      const promptResult = window.prompt('Enter the email address to send your application slip to:')
+      emailAddress = promptResult?.trim() || ''
+    }
+
+    if (!emailAddress) {
+      toast.showError?.('Email required', 'Please provide an email address to receive the slip.')
+      return
+    }
+
+    const payload: ApplicationSlipData = { ...slipPayload, email: emailAddress }
+
+    try {
+      setEmailLoading(true)
+      const result = await createApplicationSlip(payload, { toast, sendEmail: true })
+
+      if (result.error || result.emailError) {
+        const message = result.error || result.emailError || 'We could not email the slip.'
+        toast.showError?.('Email failed', message)
+        return
+      }
+
+      setSlipCache(prev => {
+        if (prev?.objectUrl && result.blob) {
+          URL.revokeObjectURL(prev.objectUrl)
+        }
+
+        const objectUrl = result.blob ? URL.createObjectURL(result.blob) : prev?.objectUrl
+
+        return {
+          objectUrl,
+          publicUrl: result.publicUrl || prev?.publicUrl,
+          path: result.path || prev?.path,
+          documentId: result.documentId || prev?.documentId
+        }
+      })
+
+      onEmailUpdate?.(emailAddress)
+    } catch (error) {
+      console.error('Slip email failed:', error)
+      const message = error instanceof Error ? error.message : 'Unable to email slip'
+      toast.showError?.('Email failed', message)
+    } finally {
+      setEmailLoading(false)
+    }
+  }, [slipPayload, submittedApplication, toast, createApplicationSlip, onEmailUpdate])
+
+  return {
+    slipCache,
+    persistingSlip,
+    slipLoading,
+    emailLoading,
+    handleDownloadSlip,
+    handleEmailSlip
+  }
+}
+
+export default useApplicationSlip


### PR DESCRIPTION
## Summary
- extract slip caching, persistence, and delivery logic into a dedicated `useApplicationSlip` hook
- update the student application wizard to consume the hook and streamline local state management
- add unit tests that cover caching behavior, persistence guardrails, download retries, and email overrides

## Testing
- npm run type-check
- npx vitest run src/pages/student/applicationWizard/__tests__/useApplicationSlip.test.tsx --environment jsdom

------
https://chatgpt.com/codex/tasks/task_e_68cc75be53808332973ea226b4839172