### PR TITLE
feat: add admin dashboard overview rpc

### DIFF
--- a/api/admin/dashboard.js
+++ b/api/admin/dashboard.js
@@ -1,6 +1,5 @@
-const { supabaseAdminClient, getUserFromRequest } = require('../_lib/supabaseClient')
-
 module.exports = async function handler(req, res) {
+  const { supabaseAdminClient, getUserFromRequest } = require('../_lib/supabaseClient')
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' })
   }
@@ -11,70 +10,81 @@ module.exports = async function handler(req, res) {
   }
 
   try {
-    const today = new Date().toISOString().split('T')[0]
-    const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().split('T')[0]
-    const monthAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0]
+    const { data, error } = await supabaseAdminClient.rpc('get_admin_dashboard_overview')
 
-    const [
-      totalApps,
-      pendingApps,
-      approvedApps,
-      rejectedApps,
-      programs,
-      intakes,
-      students,
-      todayApps,
-      weekApps,
-      monthApps,
-      recentActivity
-    ] = await Promise.all([
-      supabaseAdminClient.from('applications_new').select('*', { count: 'exact', head: true }),
-      supabaseAdminClient.from('applications_new').select('*', { count: 'exact', head: true }).eq('status', 'submitted'),
-      supabaseAdminClient.from('applications_new').select('*', { count: 'exact', head: true }).eq('status', 'approved'),
-      supabaseAdminClient.from('applications_new').select('*', { count: 'exact', head: true }).eq('status', 'rejected'),
-      supabaseAdminClient.from('programs').select('*', { count: 'exact', head: true }).eq('is_active', true),
-      supabaseAdminClient.from('intakes').select('*', { count: 'exact', head: true }).eq('is_active', true),
-      supabaseAdminClient.from('user_profiles').select('*', { count: 'exact', head: true }).eq('role', 'student'),
-      supabaseAdminClient.from('applications_new').select('*', { count: 'exact', head: true }).gte('created_at', today),
-      supabaseAdminClient.from('applications_new').select('*', { count: 'exact', head: true }).gte('created_at', weekAgo),
-      supabaseAdminClient.from('applications_new').select('*', { count: 'exact', head: true }).gte('created_at', monthAgo),
-      supabaseAdminClient
-        .from('applications_new')
-        .select('id, full_name, status, created_at, updated_at')
-        .order('updated_at', { ascending: false })
-        .limit(10)
-    ])
-
-    const stats = {
-      totalApplications: totalApps.count || 0,
-      pendingApplications: pendingApps.count || 0,
-      approvedApplications: approvedApps.count || 0,
-      rejectedApplications: rejectedApps.count || 0,
-      totalPrograms: programs.count || 0,
-      activeIntakes: intakes.count || 0,
-      totalStudents: students.count || 0,
-      todayApplications: todayApps.count || 0,
-      weekApplications: weekApps.count || 0,
-      monthApplications: monthApps.count || 0,
-      avgProcessingTime: Math.floor(Math.random() * 5) + 2,
-      systemHealth: (pendingApps.count || 0) > 50 ? 'warning' : 'good',
-      activeUsers: Math.floor(Math.random() * 20) + 5
+    if (error) {
+      throw new Error(error.message || 'Failed to load admin dashboard overview')
     }
 
-    const activities = (recentActivity.data || []).map(app => ({
-      id: app.id,
-      type: app.status === 'approved' ? 'approval' : app.status === 'rejected' ? 'rejection' : 'application',
-      message: `${app.full_name} - Application ${app.status}`,
-      timestamp: app.updated_at || app.created_at,
-      user: app.full_name
+    const overview = data || {}
+    const statusCounts = overview.status_counts || {}
+    const totals = overview.totals || {}
+    const applicationCounts = overview.application_counts || {}
+    const processingMetrics = overview.processing_metrics || {}
+    const recentItems = Array.isArray(overview.recent_activity) ? overview.recent_activity : []
+
+    const pendingApplications = (statusCounts.submitted || 0) + (statusCounts.under_review || 0)
+    const avgProcessingHours = processingMetrics.average_hours || 0
+    const avgProcessingTimeDays = Number(((avgProcessingHours || 0) / 24).toFixed(1))
+
+    const stats = {
+      totalApplications: statusCounts.total || 0,
+      pendingApplications,
+      approvedApplications: statusCounts.approved || 0,
+      rejectedApplications: statusCounts.rejected || 0,
+      totalPrograms: totals.active_programs || 0,
+      activeIntakes: totals.active_intakes || 0,
+      totalStudents: totals.students || 0,
+      todayApplications: applicationCounts.today || 0,
+      weekApplications: applicationCounts.this_week || 0,
+      monthApplications: applicationCounts.this_month || 0,
+      avgProcessingTime: avgProcessingTimeDays,
+      avgProcessingTimeHours: avgProcessingHours,
+      medianProcessingTimeHours: processingMetrics.median_hours || 0,
+      p95ProcessingTimeHours: processingMetrics.p95_hours || 0,
+      decisionVelocity24h: processingMetrics.decision_velocity_24h || 0,
+      activeUsers: processingMetrics.active_admins_last_24h || 0,
+      activeUsersLast7d: processingMetrics.active_admins_last_7d || 0,
+      systemHealth: pendingApplications > 50 || (processingMetrics.p95_hours || 0) > 96 ? 'warning' : 'good',
+      statusBreakdown: statusCounts,
+      applicationTrends: applicationCounts,
+      totalsSnapshot: totals,
+      processingMetrics
+    }
+
+    const activities = recentItems.map(item => ({
+      id: item.id,
+      type:
+        item.status === 'approved'
+          ? 'approval'
+          : item.status === 'rejected'
+            ? 'rejection'
+            : item.status === 'under_review'
+              ? 'review'
+              : 'application',
+      message: `${item.full_name} - Application ${item.status}`,
+      timestamp: item.updated_at || item.submitted_at || item.created_at,
+      user: item.full_name,
+      status: item.status,
+      paymentStatus: item.payment_status,
+      submittedAt: item.submitted_at,
+      updatedAt: item.updated_at,
+      createdAt: item.created_at,
+      program: item.program,
+      intake: item.intake
     }))
 
     return res.status(200).json({
       stats,
-      recentActivity: activities
+      recentActivity: activities,
+      statusBreakdown: statusCounts,
+      applicationTrends: applicationCounts,
+      totalsSnapshot: totals,
+      processingMetrics,
+      recentActivityRaw: recentItems
     })
   } catch (error) {
     console.error('Dashboard API error:', error)
-    return res.status(500).json({ error: 'Internal server error' })
+    return res.status(500).json({ error: 'Failed to load admin dashboard overview' })
   }
 }

--- a/supabase/functions/get_admin_dashboard_overview.sql
+++ b/supabase/functions/get_admin_dashboard_overview.sql
@@ -1,0 +1,160 @@
+-- Function: get_admin_dashboard_overview
+-- Provides aggregated metrics for the admin dashboard in a single RPC call
+
+CREATE OR REPLACE FUNCTION public.get_admin_dashboard_overview()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  overview jsonb;
+BEGIN
+  WITH status_counts AS (
+    SELECT
+      COUNT(*) AS total,
+      COUNT(*) FILTER (WHERE status = 'draft') AS draft,
+      COUNT(*) FILTER (WHERE status = 'submitted') AS submitted,
+      COUNT(*) FILTER (WHERE status = 'under_review') AS under_review,
+      COUNT(*) FILTER (WHERE status = 'approved') AS approved,
+      COUNT(*) FILTER (WHERE status = 'rejected') AS rejected
+    FROM applications_new
+  ),
+  active_programs AS (
+    SELECT COUNT(*) AS count
+    FROM programs
+    WHERE COALESCE(is_active, false) = true
+  ),
+  active_intakes AS (
+    SELECT COUNT(*) AS count
+    FROM intakes
+    WHERE COALESCE(is_active, false) = true
+      AND (
+        start_date IS NULL
+        OR end_date IS NULL
+        OR CURRENT_DATE BETWEEN start_date AND end_date
+      )
+  ),
+  student_totals AS (
+    SELECT COUNT(*) AS count
+    FROM user_profiles
+    WHERE role = 'student'
+  ),
+  date_buckets AS (
+    SELECT
+      COUNT(*) FILTER (WHERE created_at >= date_trunc('day', NOW())) AS today,
+      COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '7 days') AS this_week,
+      COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '30 days') AS this_month
+    FROM applications_new
+  ),
+  processing AS (
+    SELECT
+      ROUND(AVG(EXTRACT(EPOCH FROM (COALESCE(reviewed_at, updated_at, NOW()) - submitted_at)))/3600, 2) AS average_hours,
+      ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (
+        ORDER BY EXTRACT(EPOCH FROM (COALESCE(reviewed_at, updated_at, NOW()) - submitted_at))/3600
+      ), 2) AS median_hours,
+      ROUND(PERCENTILE_CONT(0.95) WITHIN GROUP (
+        ORDER BY EXTRACT(EPOCH FROM (COALESCE(reviewed_at, updated_at, NOW()) - submitted_at))/3600
+      ), 2) AS p95_hours,
+      COUNT(*) FILTER (
+        WHERE status IN ('approved', 'rejected')
+          AND COALESCE(reviewed_at, updated_at, NOW()) >= NOW() - INTERVAL '24 hours'
+      ) AS decision_velocity_24h,
+      COUNT(*) FILTER (WHERE status IN ('approved', 'rejected')) AS completed_count
+    FROM applications_new
+    WHERE submitted_at IS NOT NULL
+  ),
+  active_admins AS (
+    SELECT
+      COUNT(DISTINCT ds.user_id) FILTER (
+        WHERE ds.last_activity >= NOW() - INTERVAL '24 hours' AND ds.is_active = true
+      ) AS active_last_24h,
+      COUNT(DISTINCT ds.user_id) FILTER (
+        WHERE ds.last_activity >= NOW() - INTERVAL '7 days' AND ds.is_active = true
+      ) AS active_last_7d
+    FROM device_sessions ds
+    WHERE ds.user_id IN (
+      SELECT user_id
+      FROM user_roles
+      WHERE role IN ('admin', 'super_admin', 'admissions_officer')
+        AND is_active = true
+    )
+  ),
+  recent AS (
+    SELECT
+      jsonb_agg(
+        jsonb_build_object(
+          'id', a.id,
+          'full_name', a.full_name,
+          'status', a.status,
+          'payment_status', a.payment_status,
+          'submitted_at', a.submitted_at,
+          'updated_at', a.updated_at,
+          'created_at', a.created_at,
+          'program', a.program,
+          'intake', a.intake
+        )
+        ORDER BY COALESCE(a.updated_at, a.created_at) DESC
+      ) AS items
+    FROM (
+      SELECT
+        id,
+        full_name,
+        status,
+        payment_status,
+        submitted_at,
+        updated_at,
+        created_at,
+        program,
+        intake
+      FROM applications_new
+      ORDER BY COALESCE(updated_at, created_at) DESC
+      LIMIT 10
+    ) a
+  )
+  SELECT jsonb_build_object(
+    'status_counts', jsonb_build_object(
+      'total', COALESCE(status_counts.total, 0),
+      'draft', COALESCE(status_counts.draft, 0),
+      'submitted', COALESCE(status_counts.submitted, 0),
+      'under_review', COALESCE(status_counts.under_review, 0),
+      'approved', COALESCE(status_counts.approved, 0),
+      'rejected', COALESCE(status_counts.rejected, 0)
+    ),
+    'totals', jsonb_build_object(
+      'active_programs', COALESCE(active_programs.count, 0),
+      'active_intakes', COALESCE(active_intakes.count, 0),
+      'students', COALESCE(student_totals.count, 0)
+    ),
+    'application_counts', jsonb_build_object(
+      'today', COALESCE(date_buckets.today, 0),
+      'this_week', COALESCE(date_buckets.this_week, 0),
+      'this_month', COALESCE(date_buckets.this_month, 0)
+    ),
+    'processing_metrics', jsonb_build_object(
+      'average_hours', COALESCE(processing.average_hours, 0),
+      'median_hours', COALESCE(processing.median_hours, 0),
+      'p95_hours', COALESCE(processing.p95_hours, 0),
+      'decision_velocity_24h', COALESCE(processing.decision_velocity_24h, 0),
+      'completed_count', COALESCE(processing.completed_count, 0),
+      'active_admins_last_24h', COALESCE(active_admins.active_last_24h, 0),
+      'active_admins_last_7d', COALESCE(active_admins.active_last_7d, 0)
+    ),
+    'recent_activity', COALESCE(recent.items, '[]'::jsonb)
+  )
+  INTO overview
+  FROM status_counts
+  CROSS JOIN active_programs
+  CROSS JOIN active_intakes
+  CROSS JOIN student_totals
+  CROSS JOIN date_buckets
+  CROSS JOIN processing
+  CROSS JOIN active_admins
+  CROSS JOIN recent;
+
+  RETURN overview;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_admin_dashboard_overview() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_admin_dashboard_overview() TO service_role;

--- a/supabase/migrations/20250117000000_get_admin_dashboard_overview.sql
+++ b/supabase/migrations/20250117000000_get_admin_dashboard_overview.sql
@@ -1,0 +1,4 @@
+-- Deploy get_admin_dashboard_overview function
+BEGIN;
+  \ir ../functions/get_admin_dashboard_overview.sql
+COMMIT;

--- a/tests/unit/api/admin-dashboard.test.ts
+++ b/tests/unit/api/admin-dashboard.test.ts
@@ -1,0 +1,166 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRequire } from 'module'
+import type { MockInstance } from 'vitest'
+
+const rpcMock = vi.fn()
+const getUserFromRequestMock = vi.fn()
+const nodeRequire = createRequire(import.meta.url)
+const supabaseModulePath = nodeRequire.resolve('../../../api/_lib/supabaseClient.js')
+
+type StatusMock = MockInstance<[number], TestResponse>
+type JsonMock = MockInstance<[unknown], TestResponse>
+
+interface TestRequest {
+  method: string
+  headers: Record<string, string>
+}
+
+interface TestResponse {
+  statusCode: number
+  body?: unknown
+  status: StatusMock
+  json: JsonMock
+}
+
+function mockSupabaseModule() {
+  nodeRequire.cache[supabaseModulePath] = {
+    id: supabaseModulePath,
+    filename: supabaseModulePath,
+    loaded: true,
+    exports: {
+      supabaseAdminClient: { rpc: rpcMock },
+      getUserFromRequest: getUserFromRequestMock
+    }
+  }
+}
+
+function clearSupabaseModule() {
+  delete nodeRequire.cache[supabaseModulePath]
+}
+
+type Handler = (req: TestRequest, res: TestResponse) => Promise<void>
+let handler: Handler
+
+function createMockResponse(): TestResponse {
+  const response = {
+    statusCode: 200,
+    status: vi.fn<[number], TestResponse>(code => {
+      response.statusCode = code
+      return response
+    }) as StatusMock,
+    json: vi.fn<[unknown], TestResponse>(payload => {
+      response.body = payload
+      return response
+    }) as JsonMock
+  } as TestResponse
+
+  return response
+}
+
+describe('api/admin/dashboard', () => {
+  beforeAll(async () => {
+    const module = await import('../../../api/admin/dashboard.js')
+    handler = (module.default || module) as Handler
+  })
+
+  beforeEach(() => {
+    mockSupabaseModule()
+    rpcMock.mockReset()
+    getUserFromRequestMock.mockReset()
+  })
+
+  afterEach(() => {
+    clearSupabaseModule()
+  })
+
+  afterAll(() => {
+    clearSupabaseModule()
+  })
+
+  it('returns aggregated stats and recent activity from RPC payload', async () => {
+    const overview = {
+      status_counts: {
+        total: 100,
+        draft: 10,
+        submitted: 30,
+        under_review: 20,
+        approved: 25,
+        rejected: 15
+      },
+      totals: {
+        active_programs: 3,
+        active_intakes: 2,
+        students: 150
+      },
+      application_counts: {
+        today: 5,
+        this_week: 18,
+        this_month: 60
+      },
+      processing_metrics: {
+        average_hours: 48,
+        median_hours: 36,
+        p95_hours: 120,
+        decision_velocity_24h: 4,
+        completed_count: 40,
+        active_admins_last_24h: 6,
+        active_admins_last_7d: 12
+      },
+      recent_activity: [
+        {
+          id: '1',
+          full_name: 'Jane Admin',
+          status: 'approved',
+          payment_status: 'verified',
+          submitted_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-02T12:00:00Z',
+          created_at: '2025-01-01T00:00:00Z',
+          program: 'Clinical Medicine',
+          intake: 'January 2025'
+        }
+      ]
+    }
+
+    getUserFromRequestMock.mockResolvedValue({ user: { id: 'admin' }, roles: ['admin'], isAdmin: true })
+    rpcMock.mockResolvedValue({ data: overview, error: null })
+
+    const req = { method: 'GET', headers: { authorization: 'Bearer token' } }
+    const res = createMockResponse()
+
+    await handler(req, res)
+
+    expect(rpcMock).toHaveBeenCalledWith('get_admin_dashboard_overview')
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json).toHaveBeenCalledTimes(1)
+
+    const payload = res.json.mock.calls[0][0]
+
+    expect(payload.stats.totalApplications).toBe(overview.status_counts.total)
+    expect(payload.stats.pendingApplications).toBe(
+      overview.status_counts.submitted + overview.status_counts.under_review
+    )
+    expect(payload.stats.statusBreakdown).toEqual(overview.status_counts)
+    expect(payload.stats.avgProcessingTimeHours).toBe(overview.processing_metrics.average_hours)
+    expect(payload.processingMetrics.decision_velocity_24h).toBe(overview.processing_metrics.decision_velocity_24h)
+
+    expect(payload.recentActivity).toHaveLength(1)
+    expect(payload.recentActivity[0]).toMatchObject({
+      id: '1',
+      type: 'approval',
+      message: 'Jane Admin - Application approved'
+    })
+  })
+
+  it('returns an error response when the RPC fails', async () => {
+    getUserFromRequestMock.mockResolvedValue({ user: { id: 'admin' }, roles: ['admin'], isAdmin: true })
+    rpcMock.mockResolvedValue({ data: null, error: { message: 'rpc failure' } })
+
+    const req = { method: 'GET', headers: { authorization: 'Bearer token' } }
+    const res = createMockResponse()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(500)
+    expect(res.json).toHaveBeenCalledWith({ error: 'Failed to load admin dashboard overview' })
+  })
+})


### PR DESCRIPTION
## Summary
- create a get_admin_dashboard_overview SQL function and wire it into Supabase migrations
- switch the admin dashboard API to use the RPC response and return richer metrics to callers
- add unit coverage for the new RPC success and error flows

## Testing
- `npx vitest run tests/unit/api/admin-dashboard.test.ts`
- `npx eslint tests/unit/api/admin-dashboard.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68cc77298a8083328ed999abeaa8fb76