### PR TITLE
Refactor admin dashboard to use aggregated API metrics

### DIFF
--- a/api/admin/dashboard.js
+++ b/api/admin/dashboard.js
@@ -17,27 +17,61 @@ module.exports = async function handler(req, res) {
 
     const [
       totalApps,
-      pendingApps,
+      submittedApps,
+      underReviewApps,
       approvedApps,
       rejectedApps,
-      programs,
-      intakes,
-      students,
+      draftApps,
+      reviewerProfiles,
       todayApps,
       weekApps,
       monthApps,
+      processedApplications,
       recentActivity
     ] = await Promise.all([
       supabaseAdminClient.from('applications_new').select('*', { count: 'exact', head: true }),
-      supabaseAdminClient.from('applications_new').select('*', { count: 'exact', head: true }).eq('status', 'submitted'),
-      supabaseAdminClient.from('applications_new').select('*', { count: 'exact', head: true }).eq('status', 'approved'),
-      supabaseAdminClient.from('applications_new').select('*', { count: 'exact', head: true }).eq('status', 'rejected'),
-      supabaseAdminClient.from('programs').select('*', { count: 'exact', head: true }).eq('is_active', true),
-      supabaseAdminClient.from('intakes').select('*', { count: 'exact', head: true }).eq('is_active', true),
-      supabaseAdminClient.from('user_profiles').select('*', { count: 'exact', head: true }).eq('role', 'student'),
-      supabaseAdminClient.from('applications_new').select('*', { count: 'exact', head: true }).gte('created_at', today),
-      supabaseAdminClient.from('applications_new').select('*', { count: 'exact', head: true }).gte('created_at', weekAgo),
-      supabaseAdminClient.from('applications_new').select('*', { count: 'exact', head: true }).gte('created_at', monthAgo),
+      supabaseAdminClient
+        .from('applications_new')
+        .select('*', { count: 'exact', head: true })
+        .eq('status', 'submitted'),
+      supabaseAdminClient
+        .from('applications_new')
+        .select('*', { count: 'exact', head: true })
+        .eq('status', 'under_review'),
+      supabaseAdminClient
+        .from('applications_new')
+        .select('*', { count: 'exact', head: true })
+        .eq('status', 'approved'),
+      supabaseAdminClient
+        .from('applications_new')
+        .select('*', { count: 'exact', head: true })
+        .eq('status', 'rejected'),
+      supabaseAdminClient
+        .from('applications_new')
+        .select('*', { count: 'exact', head: true })
+        .eq('status', 'draft'),
+      supabaseAdminClient
+        .from('user_profiles')
+        .select('*', { count: 'exact', head: true })
+        .in('role', ['admin', 'reviewer']),
+      supabaseAdminClient
+        .from('applications_new')
+        .select('*', { count: 'exact', head: true })
+        .gte('created_at', today),
+      supabaseAdminClient
+        .from('applications_new')
+        .select('*', { count: 'exact', head: true })
+        .gte('created_at', weekAgo),
+      supabaseAdminClient
+        .from('applications_new')
+        .select('*', { count: 'exact', head: true })
+        .gte('created_at', monthAgo),
+      supabaseAdminClient
+        .from('applications_new')
+        .select('id, full_name, status, created_at, updated_at, submitted_at')
+        .in('status', ['approved', 'rejected'])
+        .order('updated_at', { ascending: false })
+        .limit(200),
       supabaseAdminClient
         .from('applications_new')
         .select('id, full_name, status, created_at, updated_at')
@@ -45,32 +79,122 @@ module.exports = async function handler(req, res) {
         .limit(10)
     ])
 
-    const stats = {
-      totalApplications: totalApps.count || 0,
-      pendingApplications: pendingApps.count || 0,
-      approvedApplications: approvedApps.count || 0,
-      rejectedApplications: rejectedApps.count || 0,
-      totalPrograms: programs.count || 0,
-      activeIntakes: intakes.count || 0,
-      totalStudents: students.count || 0,
-      todayApplications: todayApps.count || 0,
-      weekApplications: weekApps.count || 0,
-      monthApplications: monthApps.count || 0,
-      avgProcessingTime: Math.floor(Math.random() * 5) + 2,
-      systemHealth: (pendingApps.count || 0) > 50 ? 'warning' : 'good',
-      activeUsers: Math.floor(Math.random() * 20) + 5
+    const statusBreakdown = {
+      total: totalApps.count || 0,
+      draft: draftApps.count || 0,
+      submitted: submittedApps.count || 0,
+      underReview: underReviewApps.count || 0,
+      approved: approvedApps.count || 0,
+      rejected: rejectedApps.count || 0
+    }
+
+    const periodTotals = {
+      today: todayApps.count || 0,
+      last7Days: weekApps.count || 0,
+      last30Days: monthApps.count || 0
+    }
+
+    const processingDurations = (processedApplications.data || [])
+      .map(app => {
+        const start = app.submitted_at || app.created_at
+        const end = app.updated_at || app.created_at
+
+        if (!start || !end) {
+          return null
+        }
+
+        const startTime = new Date(start).getTime()
+        const endTime = new Date(end).getTime()
+
+        if (Number.isNaN(startTime) || Number.isNaN(endTime) || endTime < startTime) {
+          return null
+        }
+
+        const hours = (endTime - startTime) / (1000 * 60 * 60)
+        return Number.isFinite(hours) ? hours : null
+      })
+      .filter(value => value !== null)
+      .map(value => Number.parseFloat(value.toFixed(2)))
+
+    processingDurations.sort((a, b) => a - b)
+
+    const averageProcessingTimeHours = processingDurations.length
+      ? Number.parseFloat(
+          (
+            processingDurations.reduce((total, duration) => total + duration, 0) /
+            processingDurations.length
+          ).toFixed(2)
+        )
+      : 0
+
+    const medianProcessingTimeHours = processingDurations.length
+      ? processingDurations[Math.floor(processingDurations.length / 2)]
+      : 0
+
+    const p95Index = processingDurations.length
+      ? Math.min(processingDurations.length - 1, Math.floor(processingDurations.length * 0.95))
+      : 0
+
+    const p95ProcessingTimeHours = processingDurations.length ? processingDurations[p95Index] : 0
+
+    const processedLast7Days = (processedApplications.data || []).filter(app => {
+      const updatedAt = app.updated_at
+      if (!updatedAt) {
+        return false
+      }
+      return new Date(updatedAt) >= new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+    }).length
+
+    const throughputPerHour = Number.parseFloat(
+      (processedLast7Days / (7 * 24)).toFixed(2)
+    )
+
+    const backlog = statusBreakdown.submitted + statusBreakdown.underReview
+    const activeReviewers = reviewerProfiles.count || 0
+
+    const processingMetrics = {
+      averageProcessingTimeHours,
+      medianProcessingTimeHours,
+      p95ProcessingTimeHours,
+      throughputPerHour,
+      backlog,
+      activeReviewers
+    }
+
+    const determineSystemHealth = () => {
+      if (processingMetrics.backlog > 200 || processingMetrics.p95ProcessingTimeHours > 96) {
+        return 'critical'
+      }
+
+      if (processingMetrics.backlog > 120 || processingMetrics.p95ProcessingTimeHours > 72) {
+        return 'warning'
+      }
+
+      if (processingMetrics.backlog > 60 || processingMetrics.p95ProcessingTimeHours > 48) {
+        return 'good'
+      }
+
+      return 'excellent'
     }
 
     const activities = (recentActivity.data || []).map(app => ({
       id: app.id,
-      type: app.status === 'approved' ? 'approval' : app.status === 'rejected' ? 'rejection' : 'application',
+      type:
+        app.status === 'approved'
+          ? 'approval'
+          : app.status === 'rejected'
+            ? 'rejection'
+            : 'application',
       message: `${app.full_name} - Application ${app.status}`,
       timestamp: app.updated_at || app.created_at,
       user: app.full_name
     }))
 
     return res.status(200).json({
-      stats,
+      statusBreakdown,
+      periodTotals,
+      processingMetrics,
+      systemHealth: determineSystemHealth(),
       recentActivity: activities
     })
   } catch (error) {

--- a/src/components/admin/__tests__/FixedAdminDashboard.test.tsx
+++ b/src/components/admin/__tests__/FixedAdminDashboard.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+
+import { FixedAdminDashboard } from '../FixedAdminDashboard'
+import type { AdminDashboardMetricsResponse } from '@/services/admin/dashboard'
+import { adminDashboardService } from '@/services/admin/dashboard'
+
+vi.mock('framer-motion', async () => {
+  const actual = await vi.importActual<any>('framer-motion')
+
+  return {
+    ...actual,
+    useReducedMotion: () => true
+  }
+})
+
+vi.mock('@/services/admin/dashboard', () => ({
+  adminDashboardService: {
+    getMetrics: vi.fn()
+  }
+}))
+
+const mockDashboardMetrics: AdminDashboardMetricsResponse = {
+  statusBreakdown: {
+    total: 120,
+    draft: 10,
+    submitted: 20,
+    underReview: 15,
+    approved: 60,
+    rejected: 15
+  },
+  periodTotals: {
+    today: 5,
+    last7Days: 35,
+    last30Days: 95
+  },
+  processingMetrics: {
+    averageProcessingTimeHours: 48,
+    medianProcessingTimeHours: 36,
+    p95ProcessingTimeHours: 96,
+    throughputPerHour: 2.5,
+    backlog: 35,
+    activeReviewers: 8
+  },
+  systemHealth: 'good',
+  recentActivity: [
+    {
+      id: '1',
+      type: 'approval',
+      message: 'Jane Doe - Application approved',
+      timestamp: new Date().toISOString(),
+      user: 'Jane Doe'
+    }
+  ]
+}
+
+describe('FixedAdminDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders aggregated metrics from the dashboard service', async () => {
+    vi.mocked(adminDashboardService.getMetrics).mockResolvedValue(mockDashboardMetrics)
+
+    render(<FixedAdminDashboard />)
+
+    const todayApplications = await screen.findByTestId('today-applications')
+    expect(todayApplications).toBeTruthy()
+    expect(todayApplications.textContent).toContain('5')
+
+    expect(screen.getByTestId('pending-reviews').textContent).toContain('35')
+    expect(screen.getByTestId('approval-rate').textContent).toContain('80%')
+    expect(screen.getByTestId('avg-processing-time').textContent).toContain('2.0d')
+    expect(screen.getByTestId('processing-throughput').textContent).toContain('2.50 /hr')
+    expect(screen.getByTestId('processing-backlog').textContent).toContain('35')
+    expect(screen.getByTestId('processing-reviewers').textContent).toContain('8')
+    expect(screen.getByTestId('status-breakdown-approved').textContent).toContain('60 (50%)')
+    expect(screen.getByTestId('system-health').textContent).toContain('Good')
+    expect(screen.getByText('Jane Doe - Application approved')).toBeTruthy()
+  })
+
+  it('shows an error message when the dashboard service fails', async () => {
+    vi.mocked(adminDashboardService.getMetrics).mockRejectedValue(new Error('network error'))
+
+    render(<FixedAdminDashboard />)
+
+    const errorMessage = await screen.findByText('Failed to load dashboard metrics')
+    expect(errorMessage).toBeTruthy()
+  })
+
+  it('refreshes metrics using the dashboard service when the refresh button is clicked', async () => {
+    const getMetricsMock = vi.mocked(adminDashboardService.getMetrics)
+    getMetricsMock.mockResolvedValue(mockDashboardMetrics)
+
+    render(<FixedAdminDashboard />)
+
+    await waitFor(() => expect(getMetricsMock).toHaveBeenCalledTimes(1))
+
+    const refreshButton = screen.getByRole('button', { name: /refresh dashboard/i })
+    fireEvent.click(refreshButton)
+
+    await waitFor(() => expect(getMetricsMock).toHaveBeenCalledTimes(2))
+  })
+})

--- a/src/services/admin/dashboard.ts
+++ b/src/services/admin/dashboard.ts
@@ -1,5 +1,48 @@
 import { apiClient } from '../client'
 
+export type AdminDashboardSystemHealth = 'excellent' | 'good' | 'warning' | 'critical'
+
+export interface AdminDashboardStatusBreakdown {
+  total: number
+  draft: number
+  submitted: number
+  underReview: number
+  approved: number
+  rejected: number
+}
+
+export interface AdminDashboardPeriodTotals {
+  today: number
+  last7Days: number
+  last30Days: number
+}
+
+export interface AdminDashboardProcessingMetrics {
+  averageProcessingTimeHours: number
+  medianProcessingTimeHours: number
+  p95ProcessingTimeHours: number
+  throughputPerHour: number
+  backlog: number
+  activeReviewers: number
+}
+
+export interface AdminDashboardActivityItem {
+  id: string
+  type: 'application' | 'approval' | 'rejection' | 'system'
+  message: string
+  timestamp: string
+  user?: string
+}
+
+export interface AdminDashboardMetricsResponse {
+  statusBreakdown: AdminDashboardStatusBreakdown
+  periodTotals: AdminDashboardPeriodTotals
+  processingMetrics: AdminDashboardProcessingMetrics
+  systemHealth: AdminDashboardSystemHealth
+  recentActivity: AdminDashboardActivityItem[]
+}
+
 export const adminDashboardService = {
-  getMetrics: () => apiClient.request('/api/admin/dashboard')
+  getMetrics: async (): Promise<AdminDashboardMetricsResponse> =>
+    apiClient.request('/api/admin/dashboard')
 }


### PR DESCRIPTION
## Summary
- expand the `/api/admin/dashboard` handler to return typed status breakdowns, period totals, processing metrics, and recent activity for the admin UI.
- refactor `FixedAdminDashboard` to consume the new service payload, consolidate loading/error handling, and render updated processing and distribution widgets from the aggregated data.
- document the richer response in the dashboard service and cover the new UI surface with Vitest checks that stub the API helper instead of Supabase queries.

## Testing
- `npx vitest run src/components/admin/__tests__/FixedAdminDashboard.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ccb6d8afb48332b2cd403cebad1852