### PR TITLE
Cache admin dashboard metrics snapshot

### DIFF
--- a/supabase/functions/refresh_admin_dashboard_metrics_cache.sql
+++ b/supabase/functions/refresh_admin_dashboard_metrics_cache.sql
@@ -1,0 +1,25 @@
+-- Function: refresh_admin_dashboard_metrics_cache
+-- Recomputes and stores the admin dashboard overview snapshot
+
+CREATE OR REPLACE FUNCTION public.refresh_admin_dashboard_metrics_cache()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  overview jsonb;
+BEGIN
+  SELECT public.get_admin_dashboard_overview() INTO overview;
+
+  INSERT INTO public.admin_dashboard_metrics_cache AS cache (id, metrics, generated_at)
+  VALUES ('overview', overview, NOW())
+  ON CONFLICT (id)
+  DO UPDATE
+    SET metrics = EXCLUDED.metrics,
+        generated_at = EXCLUDED.generated_at;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.refresh_admin_dashboard_metrics_cache() TO service_role;
+GRANT EXECUTE ON FUNCTION public.refresh_admin_dashboard_metrics_cache() TO authenticated;

--- a/supabase/migrations/20250221000000_admin_dashboard_metrics_cache.sql
+++ b/supabase/migrations/20250221000000_admin_dashboard_metrics_cache.sql
@@ -1,0 +1,51 @@
+-- Deploy admin_dashboard_metrics_cache snapshot storage and refresh job
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+BEGIN;
+  CREATE TABLE IF NOT EXISTS public.admin_dashboard_metrics_cache (
+    id text PRIMARY KEY,
+    metrics jsonb NOT NULL DEFAULT '{}'::jsonb,
+    generated_at timestamptz NOT NULL DEFAULT NOW()
+  );
+
+  COMMENT ON TABLE public.admin_dashboard_metrics_cache IS 'Stores cached admin dashboard overview metrics for quick retrieval.';
+  COMMENT ON COLUMN public.admin_dashboard_metrics_cache.metrics IS 'Serialized metrics payload produced by get_admin_dashboard_overview.';
+  COMMENT ON COLUMN public.admin_dashboard_metrics_cache.generated_at IS 'Timestamp indicating when the snapshot was generated.';
+
+  GRANT SELECT ON TABLE public.admin_dashboard_metrics_cache TO authenticated;
+  GRANT SELECT ON TABLE public.admin_dashboard_metrics_cache TO service_role;
+
+  \ir ../functions/refresh_admin_dashboard_metrics_cache.sql
+
+  -- Ensure a fresh cron schedule exists to refresh the snapshot every minute
+  DO $$
+  DECLARE
+    existing_job_id bigint;
+  BEGIN
+    IF EXISTS (
+      SELECT 1
+      FROM cron.job
+      WHERE jobname = 'refresh-admin-dashboard-metrics-cache'
+    ) THEN
+      SELECT jobid
+      INTO existing_job_id
+      FROM cron.job
+      WHERE jobname = 'refresh-admin-dashboard-metrics-cache'
+      LIMIT 1;
+
+      IF existing_job_id IS NOT NULL THEN
+        PERFORM cron.unschedule(existing_job_id);
+      END IF;
+    END IF;
+
+    PERFORM cron.schedule(
+      'refresh-admin-dashboard-metrics-cache',
+      '* * * * *',
+      $$SELECT public.refresh_admin_dashboard_metrics_cache();$$
+    );
+  END
+  $$;
+
+  -- Seed the cache immediately so the API has data before the first cron run
+  PERFORM public.refresh_admin_dashboard_metrics_cache();
+COMMIT;


### PR DESCRIPTION
## Summary
- add a cached admin dashboard metrics table and refresh function scheduled via pg_cron
- expose a refresh helper and read cached payload (with cache headers) in the admin dashboard API
- surface the cached generatedAt metadata through the admin dashboard service and update unit tests

## Testing
- CI=1 npx vitest tests/unit/api/admin-dashboard.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ccc64f947c8332b434048422e2162e