### PR TITLE
Fix Tailwind height token for large buttons

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -43,7 +43,7 @@ export function Button({
   const sizeClasses = {
     sm: 'h-9 px-4 text-sm',
     md: 'h-11 px-6 text-base',
-    lg: 'h-13 px-8 text-lg',
+    lg: 'h-btn-lg px-8 text-lg',
     xl: 'h-16 px-10 text-xl'
   }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,9 +15,9 @@ module.exports = {
 				'2xl': '1400px',
 			},
 		},
-		extend: {
-			colors: {
-				border: 'hsl(var(--border))',
+                extend: {
+                        colors: {
+                                border: 'hsl(var(--border))',
 				input: 'hsl(var(--input))',
 				ring: 'hsl(var(--ring))',
 				background: 'hsl(var(--background))',
@@ -51,11 +51,14 @@ module.exports = {
 					foreground: 'hsl(var(--card-foreground))',
 				},
 			},
-			borderRadius: {
-				lg: 'var(--radius)',
-				md: 'calc(var(--radius) - 2px)',
-				sm: 'calc(var(--radius) - 4px)',
-			},
+                        borderRadius: {
+                                lg: 'var(--radius)',
+                                md: 'calc(var(--radius) - 2px)',
+                                sm: 'calc(var(--radius) - 4px)',
+                        },
+                        height: {
+                                'btn-lg': '3.25rem',
+                        },
 			keyframes: {
 				'accordion-down': {
 					from: { height: 0 },


### PR DESCRIPTION
## Summary
- update the large button size class to use a valid Tailwind height utility
- register a custom `btn-lg` height value in the Tailwind theme so the large size renders at the intended 52px

## Testing
- npm run lint *(fails: existing lint errors and warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ccdb53e64883329c04606c2c1861fb