### PR TITLE
Adjust mobile nav focus ring width

### DIFF
--- a/src/components/ui/MobileNavigation.tsx
+++ b/src/components/ui/MobileNavigation.tsx
@@ -148,7 +148,7 @@ export function MobileNavigation({ className }: MobileNavigationProps) {
 
         {/* Mobile Menu Button */}
         <motion.button
-          className="md:hidden p-3 rounded-xl text-white bg-black/40 hover:bg-black/60 backdrop-blur-sm transition-all duration-300 focus:outline-none focus:ring-3 focus:ring-primary/60 shadow-lg hover:shadow-xl border border-white/30 hover:border-white/50 min-h-[48px] min-w-[48px]"
+          className="md:hidden p-3 rounded-xl text-white bg-black/40 hover:bg-black/60 backdrop-blur-sm transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-primary/60 shadow-lg hover:shadow-xl border border-white/30 hover:border-white/50 min-h-[48px] min-w-[48px]"
           onClick={toggleMenu}
           whileTap={{ scale: 0.95 }}
           aria-label={isOpen ? "Close menu" : "Open menu"}


### PR DESCRIPTION
## Summary
- replace unsupported `focus:ring-3` utility on the mobile navigation toggle with the supported `focus:ring-2`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cce833cddc8332b0c9041d97f58ff3