### PR TITLE
feat: refresh auth flows with shared layout

### DIFF
--- a/src/pages/auth/AuthLayout.tsx
+++ b/src/pages/auth/AuthLayout.tsx
@@ -1,0 +1,102 @@
+import { type ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { ArrowLeft, GraduationCap } from 'lucide-react'
+
+interface AuthLayoutProps {
+  title: string
+  description?: ReactNode
+  children: ReactNode
+  footer?: ReactNode
+  hero?: ReactNode
+  backLinkLabel?: string
+  backLinkHref?: string
+}
+
+const defaultHero = (
+  <div className="mx-auto max-w-xl text-center text-white lg:mx-0 lg:text-left">
+    <span className="inline-flex items-center gap-2 rounded-full border border-white/30 bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-white/80 backdrop-blur">
+      <span className="h-2 w-2 rounded-full bg-accent" aria-hidden />
+      MIHAS Student Portal
+    </span>
+    <div className="mt-6 space-y-4">
+      <h1 className="text-4xl font-semibold leading-tight sm:text-5xl">Grow your healthcare career with confidence</h1>
+      <p className="text-base leading-relaxed text-white/80">
+        Access your personalized portal to monitor applications, manage enrollment tasks, and stay connected with our admissions team every step of the way.
+      </p>
+    </div>
+    <div className="mt-8 grid gap-4 sm:grid-cols-2">
+      <div className="rounded-2xl border border-white/20 bg-white/10 p-4 text-left backdrop-blur">
+        <p className="text-sm font-semibold text-white">24/7 Access</p>
+        <p className="mt-1 text-sm text-white/70">Manage your journey from any device at any time.</p>
+      </div>
+      <div className="rounded-2xl border border-white/20 bg-white/10 p-4 text-left backdrop-blur">
+        <p className="text-sm font-semibold text-white">Dedicated Support</p>
+        <p className="mt-1 text-sm text-white/70">Our advisors are ready to help you take the next step.</p>
+      </div>
+    </div>
+  </div>
+)
+
+export function AuthLayout({
+  title,
+  description,
+  children,
+  footer,
+  hero = defaultHero,
+  backLinkHref = '/',
+  backLinkLabel = 'Back to Home',
+}: AuthLayoutProps) {
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-primary/20 via-secondary/10 to-white">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(20,184,166,0.18),transparent_45%),radial-gradient(circle_at_bottom,_rgba(147,51,234,0.18),transparent_55%)]" aria-hidden />
+      <div className="absolute inset-x-0 top-0 h-40 bg-gradient-to-b from-white/60 to-transparent" aria-hidden />
+      <div className="absolute inset-x-0 bottom-0 h-40 bg-gradient-to-t from-white/60 to-transparent" aria-hidden />
+
+      <div className="relative z-10 mx-auto flex w-full max-w-6xl flex-col gap-12 px-4 py-16 sm:px-6 lg:grid lg:grid-cols-[1.1fr_minmax(0,1fr)] lg:items-center lg:gap-16 lg:px-8">
+        <div className="order-2 lg:order-1">
+          {hero}
+        </div>
+
+        <div className="order-1 lg:order-2">
+          <div className="relative">
+            <div className="pointer-events-none absolute inset-0 rounded-[32px] bg-white/60 blur-3xl" aria-hidden />
+            <div className="relative flex flex-col gap-8 rounded-[32px] border border-white/60 bg-white/80 p-8 shadow-2xl backdrop-blur-xl sm:p-10">
+              <div className="space-y-6 text-center sm:text-left">
+                <Link
+                  to={backLinkHref}
+                  className="inline-flex items-center justify-center gap-2 text-sm font-semibold text-primary transition-colors hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white rounded-full px-3 py-1"
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                  {backLinkLabel}
+                </Link>
+                <div className="flex items-center justify-center sm:justify-start">
+                  <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-primary via-secondary to-accent text-white shadow-lg">
+                    <GraduationCap className="h-7 w-7" />
+                  </div>
+                </div>
+                <div>
+                  <h2 className="text-3xl font-semibold text-secondary sm:text-4xl">{title}</h2>
+                  {description && (
+                    <p className="mt-3 text-base text-secondary/80">
+                      {description}
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              <div>
+                {children}
+              </div>
+
+              {footer && (
+                <div className="border-t border-secondary/10 pt-8">
+                  {footer}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/auth/SignInPage.tsx
+++ b/src/pages/auth/SignInPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -6,7 +6,7 @@ import { z } from 'zod'
 import { useAuth } from '@/contexts/AuthContext'
 import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
-import { GraduationCap, ArrowLeft } from 'lucide-react'
+import { AuthLayout } from './AuthLayout'
 import { networkDiagnostics } from '@/lib/networkDiagnostics'
 
 const signInSchema = z.object({
@@ -21,7 +21,6 @@ export default function SignInPage() {
   const { signIn } = useAuth()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
-  const [networkStatus, setNetworkStatus] = useState<'checking' | 'online' | 'offline' | 'slow'>('online')
   
   const {
     register,
@@ -35,12 +34,10 @@ export default function SignInPage() {
     console.log('Login attempt:', data.email)
     setLoading(true)
     setError('')
-    setNetworkStatus('checking')
 
     try {
       // Quick network check
       const connectionTest = await networkDiagnostics.testConnection()
-      setNetworkStatus(connectionTest.status)
       
       if (connectionTest.status === 'offline') {
         setError('Network connection unavailable. Please check your internet connection.')
@@ -69,86 +66,74 @@ export default function SignInPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
-      <div className="sm:mx-auto sm:w-full sm:max-w-md">
-        <Link to="/" className="flex items-center justify-center text-blue-600 hover:text-blue-700 mb-6">
-          <ArrowLeft className="h-4 w-4 mr-2" />
-          Back to Home
-        </Link>
-        
-        <div className="flex items-center justify-center mb-6">
-          <GraduationCap className="h-12 w-12 text-blue-600" />
-        </div>
-        
-        <h2 className="mt-6 text-center text-3xl font-bold text-gray-900">
-          Sign in to your account
-        </h2>
-        <p className="mt-2 text-center text-sm text-gray-600">
+    <AuthLayout
+      title="Sign in to your account"
+      description={(
+        <>
           Or{' '}
           <Link
             to="/auth/signup"
-            className="font-medium text-blue-600 hover:text-blue-700"
+            className="font-semibold text-primary transition-colors hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white rounded-md"
           >
             create a new account
           </Link>
-        </p>
-      </div>
-
-      <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-        <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
-          <form className="space-y-6" onSubmit={handleSubmit(onSubmit)}>
-            <Input
-              {...register('email')}
-              type="email"
-              label="Email address"
-              error={errors.email?.message}
-              required
-            />
-
-            <Input
-              {...register('password')}
-              type="password"
-              label="Password"
-              error={errors.password?.message}
-              required
-            />
-
-            {error && (
-              <div className="rounded-md bg-red-50 p-4">
-                <div className="text-sm text-red-700">{error}</div>
-              </div>
-            )}
-
-            <Button
-              type="submit"
-              className="w-full"
-              loading={loading}
-            >
-              Sign in
-            </Button>
-          </form>
-
-          <div className="mt-6">
-            <div className="relative">
-              <div className="absolute inset-0 flex items-center">
-                <div className="w-full border-t border-gray-300" />
-              </div>
-              <div className="relative flex justify-center text-sm">
-                <span className="px-2 bg-white text-gray-500">Need help?</span>
-              </div>
+        </>
+      )}
+      footer={(
+        <div className="space-y-6">
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-secondary/20" />
             </div>
-
-            <div className="mt-6 text-center">
-              <Link
-                to="/auth/forgot-password"
-                className="text-sm text-blue-600 hover:text-blue-700"
-              >
-                Forgot your password?
-              </Link>
+            <div className="relative flex justify-center text-sm">
+              <span className="bg-white/80 px-3 py-0.5 text-secondary/70">Need help?</span>
             </div>
           </div>
+
+          <div className="text-center">
+            <Link
+              to="/auth/forgot-password"
+              className="text-sm font-semibold text-primary transition-colors hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white rounded-md"
+            >
+              Forgot your password?
+            </Link>
+          </div>
         </div>
-      </div>
-    </div>
+      )}
+    >
+      <form className="space-y-6" onSubmit={handleSubmit(onSubmit)}>
+        <Input
+          {...register('email')}
+          type="email"
+          label="Email address"
+          error={errors.email?.message}
+          required
+        />
+
+        <Input
+          {...register('password')}
+          type="password"
+          label="Password"
+          error={errors.password?.message}
+          required
+        />
+
+        {error && (
+          <div className="rounded-xl border border-red-200/70 bg-red-50/80 p-4 text-left shadow-sm">
+            <div className="text-sm font-medium text-red-700">{error}</div>
+          </div>
+        )}
+
+        <Button
+          type="submit"
+          className="w-full"
+          loading={loading}
+          variant="gradient"
+          size="lg"
+        >
+          Sign in
+        </Button>
+      </form>
+    </AuthLayout>
   )
 }

--- a/src/pages/auth/SignUpPage.tsx
+++ b/src/pages/auth/SignUpPage.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
 import { TextArea } from '@/components/ui/TextArea'
 import { Turnstile } from '@/components/ui/Turnstile'
-import { GraduationCap, ArrowLeft } from 'lucide-react'
+import { AuthLayout } from './AuthLayout'
 
 const signUpSchema = z.object({
   email: z.string().email('Please enter a valid email address'),
@@ -56,8 +56,6 @@ export default function SignUpPage() {
     }
   }, [success, navigate])
 
-
-
   const handleTurnstileVerify = useCallback((token: string) => {
     setTurnstileToken(token)
     setError('')
@@ -87,7 +85,8 @@ export default function SignUpPage() {
 
     try {
       // Proceed with sign up
-      const { confirmPassword: _confirmPassword, ...userData } = data
+      const { confirmPassword, ...userData } = data
+      void confirmPassword
       const result = await signUp(data.email, data.password, userData)
 
       if (result?.error) {
@@ -108,220 +107,213 @@ export default function SignUpPage() {
 
   if (success) {
     return (
-      <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
-        <div className="sm:mx-auto sm:w-full sm:max-w-md">
-          <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
-            <div className="text-center">
-              <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-green-100 mb-4">
-                <svg className="h-6 w-6 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                </svg>
-              </div>
-              <h3 className="text-lg font-medium text-secondary mb-2">Account Created Successfully!</h3>
-              <p className="text-sm text-secondary mb-6">{success}</p>
-              <p className="text-xs text-gray-500 mb-6">Redirecting to sign in page...</p>
-              <div className="space-y-3">
-                <Link to="/auth/signin">
-                  <Button className="w-full">
-                    Go to Sign In Now
-                  </Button>
-                </Link>
-                <Link to="/">
-                  <Button variant="outline" className="w-full">
-                    Back to Home
-                  </Button>
-                </Link>
-              </div>
-            </div>
+      <AuthLayout
+        title="Account created successfully!"
+        description={success}
+      >
+        <div className="space-y-6 text-center">
+          <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full border-2 border-primary/30 bg-primary/10 text-primary">
+            <svg className="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+            </svg>
+          </div>
+          <p className="text-sm text-secondary/80">Redirecting to sign in page...</p>
+          <div className="space-y-3">
+            <Link to="/auth/signin" className="block">
+              <Button className="w-full" variant="gradient" size="lg">
+                Go to Sign In Now
+              </Button>
+            </Link>
+            <Link
+              to="/"
+              className="block"
+            >
+              <Button variant="outline" className="w-full" size="lg">
+                Back to Home
+              </Button>
+            </Link>
           </div>
         </div>
-      </div>
+      </AuthLayout>
     )
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 py-12 sm:px-6 lg:px-8">
-      <div className="sm:mx-auto sm:w-full sm:max-w-2xl">
-        <Link to="/" className="flex items-center justify-center text-blue-600 hover:text-blue-700 mb-6">
-          <ArrowLeft className="h-4 w-4 mr-2" />
-          Back to Home
-        </Link>
-        
-        <div className="flex items-center justify-center mb-6">
-          <GraduationCap className="h-12 w-12 text-blue-600" />
-        </div>
-        
-        <h2 className="mt-6 text-center text-3xl font-bold text-gray-900">
-          Create your account
-        </h2>
-        <p className="mt-2 text-center text-sm text-gray-600">
+    <AuthLayout
+      title="Create your account"
+      description={(
+        <>
           Already have an account?{' '}
           <Link
             to="/auth/signin"
-            className="font-medium text-blue-600 hover:text-blue-700"
+            className="font-semibold text-primary transition-colors hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white rounded-md"
           >
             Sign in here
           </Link>
-        </p>
-      </div>
+        </>
+      )}
+    >
+      <form className="space-y-6" onSubmit={handleSubmit(onSubmit)}>
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          <Input
+            {...register('full_name')}
+            type="text"
+            label="Full Name"
+            error={errors.full_name?.message}
+            required
+          />
 
-      <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-2xl">
-        <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
-          <form className="space-y-6" onSubmit={handleSubmit(onSubmit)}>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <Input
-                {...register('full_name')}
-                type="text"
-                label="Full Name"
-                error={errors.full_name?.message}
-                required
-              />
-              
-              <Input
-                {...register('email')}
-                type="email"
-                label="Email Address"
-                error={errors.email?.message}
-                required
-              />
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <Input
-                {...register('password')}
-                type="password"
-                label="Create Password"
-                error={errors.password?.message}
-                helperText="Must be at least 6 characters"
-                required
-              />
-              
-              <Input
-                {...register('confirmPassword')}
-                type="password"
-                label="Confirm Password"
-                error={errors.confirmPassword?.message}
-                required
-              />
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <Input
-                {...register('phone')}
-                type="tel"
-                label="Phone Number"
-                error={errors.phone?.message}
-                required
-              />
-              
-              <Input
-                {...register('date_of_birth')}
-                type="date"
-                label="Date of Birth"
-                error={errors.date_of_birth?.message}
-                required
-              />
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <div>
-                <label htmlFor="sex" className="block text-sm font-medium text-secondary mb-1">
-                  Sex <span className="text-red-500">*</span>
-                </label>
-                <select
-                  {...register('sex')}
-                  id="sex"
-                  className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
-                >
-                  <option value="">Select Sex</option>
-                  <option value="Male">Male</option>
-                  <option value="Female">Female</option>
-                </select>
-                {errors.sex && (
-                  <p className="mt-1 text-sm text-red-600">{errors.sex.message}</p>
-                )}
-              </div>
-              
-              <Input
-                {...register('nationality')}
-                type="text"
-                label="Nationality"
-                error={errors.nationality?.message}
-                required
-              />
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <TextArea
-                {...register('address')}
-                label="Full Address"
-                error={errors.address?.message}
-                rows={3}
-                required
-              />
-              
-              <Input
-                {...register('city')}
-                type="text"
-                label="City"
-                error={errors.city?.message}
-                required
-              />
-            </div>
-
-            <div className="border-t pt-6">
-              <h3 className="text-lg font-medium text-secondary mb-4">Next of Kin</h3>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <Input
-                  {...register('next_of_kin_name')}
-                  type="text"
-                  label="Next of Kin Name"
-                  error={errors.next_of_kin_name?.message}
-                  required
-                />
-                
-                <Input
-                  {...register('next_of_kin_phone')}
-                  type="tel"
-                  label="Next of Kin Phone"
-                  error={errors.next_of_kin_phone?.message}
-                  required
-                />
-              </div>
-            </div>
-
-            {import.meta.env.VITE_TURNSTILE_SITE_KEY && (
-              <div className="border-t pt-6">
-                <h3 className="text-lg font-medium text-secondary mb-4">Security Verification</h3>
-                <div className="flex justify-center">
-                  <Turnstile
-                    key={turnstileKey}
-                    siteKey={import.meta.env.VITE_TURNSTILE_SITE_KEY}
-                    onVerify={handleTurnstileVerify}
-                    onError={handleTurnstileError}
-                    onExpire={handleTurnstileExpire}
-                  />
-                </div>
-              </div>
-            )}
-
-            {error && (
-              <div className="rounded-md bg-red-50 p-4">
-                <div className="text-sm text-red-700">{error}</div>
-              </div>
-            )}
-
-            <Button
-              type="submit"
-              className="w-full"
-              loading={loading}
-              disabled={import.meta.env.VITE_TURNSTILE_SITE_KEY && !turnstileToken}
-            >
-              Create Account
-            </Button>
-          </form>
+          <Input
+            {...register('email')}
+            type="email"
+            label="Email Address"
+            error={errors.email?.message}
+            required
+          />
         </div>
-      </div>
-    </div>
+
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          <Input
+            {...register('password')}
+            type="password"
+            label="Create Password"
+            error={errors.password?.message}
+            helperText="Must be at least 6 characters"
+            required
+          />
+
+          <Input
+            {...register('confirmPassword')}
+            type="password"
+            label="Confirm Password"
+            error={errors.confirmPassword?.message}
+            required
+          />
+        </div>
+
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          <Input
+            {...register('phone')}
+            type="tel"
+            label="Phone Number"
+            error={errors.phone?.message}
+            required
+          />
+
+          <Input
+            {...register('date_of_birth')}
+            type="date"
+            label="Date of Birth"
+            error={errors.date_of_birth?.message}
+            required
+          />
+        </div>
+
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          <div>
+            <label htmlFor="sex" className="mb-1 block text-sm font-medium text-secondary">
+              Sex <span className="text-red-500">*</span>
+            </label>
+            <select
+              {...register('sex')}
+              id="sex"
+              className="w-full rounded-md border border-secondary/30 bg-white px-3 py-2 text-sm text-secondary placeholder:text-secondary/60 transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+            >
+              <option value="">Select Sex</option>
+              <option value="Male">Male</option>
+              <option value="Female">Female</option>
+            </select>
+            {errors.sex && (
+              <p className="mt-1 text-sm text-red-600">{errors.sex.message}</p>
+            )}
+          </div>
+
+          <Input
+            {...register('nationality')}
+            type="text"
+            label="Nationality"
+            error={errors.nationality?.message}
+            required
+          />
+        </div>
+
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          <TextArea
+            {...register('address')}
+            label="Full Address"
+            error={errors.address?.message}
+            rows={3}
+            required
+          />
+
+          <Input
+            {...register('city')}
+            type="text"
+            label="City"
+            error={errors.city?.message}
+            required
+          />
+        </div>
+
+        <div className="rounded-2xl border border-secondary/10 bg-secondary/5 p-6">
+          <h3 className="text-lg font-semibold text-secondary">Next of Kin</h3>
+          <p className="mt-1 text-sm text-secondary/70">
+            Provide the details of a trusted contact we can reach in case of emergencies.
+          </p>
+          <div className="mt-4 grid grid-cols-1 gap-6 md:grid-cols-2">
+            <Input
+              {...register('next_of_kin_name')}
+              type="text"
+              label="Next of Kin Name"
+              error={errors.next_of_kin_name?.message}
+              required
+            />
+
+            <Input
+              {...register('next_of_kin_phone')}
+              type="tel"
+              label="Next of Kin Phone"
+              error={errors.next_of_kin_phone?.message}
+              required
+            />
+          </div>
+        </div>
+
+        {import.meta.env.VITE_TURNSTILE_SITE_KEY && (
+          <div className="rounded-2xl border border-secondary/10 bg-white/80 p-6">
+            <h3 className="text-lg font-semibold text-secondary">Security Verification</h3>
+            <p className="mt-1 text-sm text-secondary/70">
+              Complete the verification step to keep your account secure.
+            </p>
+            <div className="mt-4 flex justify-center">
+              <Turnstile
+                key={turnstileKey}
+                siteKey={import.meta.env.VITE_TURNSTILE_SITE_KEY}
+                onVerify={handleTurnstileVerify}
+                onError={handleTurnstileError}
+                onExpire={handleTurnstileExpire}
+              />
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <div className="rounded-xl border border-red-200/70 bg-red-50/80 p-4 text-left shadow-sm">
+            <div className="text-sm font-medium text-red-700">{error}</div>
+          </div>
+        )}
+
+        <Button
+          type="submit"
+          className="w-full"
+          loading={loading}
+          disabled={import.meta.env.VITE_TURNSTILE_SITE_KEY && !turnstileToken}
+          variant="gradient"
+          size="lg"
+        >
+          Create Account
+        </Button>
+      </form>
+    </AuthLayout>
   )
 }


### PR DESCRIPTION
## Summary
- add a reusable `AuthLayout` that applies the gradient shell, glassmorphism card, and shared hero copy for auth flows
- migrate the sign-in and sign-up pages to the shared layout, align links with the design palette, and switch CTAs to the gradient button variant
- refine the sign-up experience with contextual helper copy, themed success state, and updated select styling

## Testing
- `npm run lint` *(fails: existing repo lint issues outside auth pages)*
- `npx eslint src/pages/auth/AuthLayout.tsx src/pages/auth/SignInPage.tsx src/pages/auth/SignUpPage.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68cce927dc548332afc81e9fe1006cde