### PR TITLE
Refactor analytics API into single handler

### DIFF
--- a/API_CONSOLIDATION_GUIDE.md
+++ b/API_CONSOLIDATION_GUIDE.md
@@ -93,7 +93,7 @@ fetch('https://your-project.supabase.co/functions/v1/mcp-operations?action=schem
 1. `/api/catalog.js` (consolidated)
 2. `/api/auth.js` (consolidated)
 3. `/api/notifications.js` (consolidated)
-4. `/api/analytics/metrics.js`
+4. `/api/analytics/index.js`
 5. `/api/applications/[id].js`
 6. `/api/applications/index.js`
 7. `/api/applications/bulk.js`

--- a/API_CONSOLIDATION_STATUS.md
+++ b/API_CONSOLIDATION_STATUS.md
@@ -21,7 +21,7 @@ Successfully consolidated from 20+ to 12 serverless functions to meet Vercel Hob
    - `POST /api/notifications?action=application-submitted`
 
 ### Remaining Individual APIs ✅
-4. `/api/analytics/metrics.js`
+4. `/api/analytics/index.js`
 5. `/api/applications/[id].js`
 6. `/api/applications/index.js`
 7. `/api/applications/bulk.js`

--- a/DEPLOYMENT_CHECKLIST.md
+++ b/DEPLOYMENT_CHECKLIST.md
@@ -20,7 +20,7 @@ api/
 ├── catalog.js           # Consolidated: subjects, programs, intakes
 ├── auth.js             # Consolidated: login, signin, register  
 ├── notifications.js    # Consolidated: send, application-submitted
-├── analytics/metrics.js
+├── analytics/index.js
 ├── applications/[id].js
 ├── applications/index.js
 ├── applications/bulk.js

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The MIHAS/KATC Application System is a **fully operational production system** s
 - **Application Management** (`/api/applications`)
 - **Document Processing** (`/api/documents`)
 - **Notification Service** (`/api/notifications`)
-- **Analytics Service** (`/api/analytics`)
+- **Analytics Service** (`/api/analytics?action=metrics|predictive-dashboard|telemetry`)
 
 ## 📈 Production Statistics
 

--- a/api/_lib/analytics/metrics.js
+++ b/api/_lib/analytics/metrics.js
@@ -1,16 +1,12 @@
-const { supabaseAdminClient, getUserFromRequest } = require('../_lib/supabaseClient')
+const { supabaseAdminClient, getUserFromRequest } = require('../supabaseClient')
 const {
   checkRateLimit,
   buildRateLimitKey,
   getLimiterConfig,
   attachRateLimitHeaders
-} = require('../_lib/rateLimiter')
+} = require('../rateLimiter')
 
-module.exports = async function handler(req, res) {
-  if (req.method !== 'GET') {
-    return res.status(405).json({ error: 'Method not allowed' })
-  }
-
+async function handleMetricsRequest(req, res) {
   try {
     const rateKey = buildRateLimitKey(req, { prefix: 'analytics-metrics' })
     const rateResult = await checkRateLimit(
@@ -20,7 +16,9 @@ module.exports = async function handler(req, res) {
 
     if (rateResult.isLimited) {
       attachRateLimitHeaders(res, rateResult)
-      return res.status(429).json({ error: 'Too many analytics requests. Please try again later.' })
+      return res
+        .status(429)
+        .json({ error: 'Too many analytics requests. Please try again later.' })
     }
   } catch (rateError) {
     console.error('Analytics metrics rate limiter error:', rateError)
@@ -63,4 +61,8 @@ module.exports = async function handler(req, res) {
     console.error('Analytics metrics error', error)
     return res.status(500).json({ error: 'Internal server error' })
   }
+}
+
+module.exports = {
+  handleMetricsRequest
 }

--- a/api/analytics/index.js
+++ b/api/analytics/index.js
@@ -1,0 +1,46 @@
+const { handleMetricsRequest } = require('../_lib/analytics/metrics')
+const { handlePredictiveDashboardRequest } = require('../_lib/analytics/predictiveDashboard')
+const { handleTelemetryFetch, handleTelemetryIngest } = require('../_lib/analytics/telemetry')
+
+const ACTION_HANDLERS = {
+  metrics: {
+    GET: handleMetricsRequest
+  },
+  'predictive-dashboard': {
+    GET: handlePredictiveDashboardRequest
+  },
+  telemetry: {
+    GET: handleTelemetryFetch,
+    POST: handleTelemetryIngest
+  }
+}
+
+function normalizeAction(action) {
+  if (Array.isArray(action)) {
+    return action[0]
+  }
+  return action
+}
+
+module.exports = async function handler(req, res) {
+  const actionParam = normalizeAction(req.query?.action)
+  const actionKey = typeof actionParam === 'string' ? actionParam.toLowerCase() : undefined
+
+  if (!actionKey) {
+    return res.status(400).json({ error: 'Missing analytics action' })
+  }
+
+  const handlers = ACTION_HANDLERS[actionKey]
+  if (!handlers) {
+    return res.status(400).json({ error: `Unsupported analytics action: ${actionParam}` })
+  }
+
+  const method = (req.method || 'GET').toUpperCase()
+  const actionHandler = handlers[method]
+  if (!actionHandler) {
+    res.setHeader('Allow', Object.keys(handlers).join(', '))
+    return res.status(405).json({ error: `Method ${method} not allowed for action ${actionKey}` })
+  }
+
+  return actionHandler(req, res)
+}

--- a/docs/MICROSERVICES_ARCHITECTURE.md
+++ b/docs/MICROSERVICES_ARCHITECTURE.md
@@ -32,8 +32,11 @@ The MIHAS application has been restructured into a serverless microservices arch
 ### Notification Service (`/api/notifications/`)
 - `POST /api/notifications/send` - Send notifications
 
-### Analytics Service (`/api/analytics/`)
-- `GET /api/analytics/metrics` - Get system metrics
+### Analytics Service (`/api/analytics`)
+- `GET /api/analytics?action=metrics` - Get system metrics
+- `GET /api/analytics?action=predictive-dashboard` - Predictive analytics overview
+- `GET /api/analytics?action=telemetry` - Admin telemetry insights
+- `POST /api/analytics?action=telemetry` - Telemetry ingestion endpoint
 
 ## 🔧 Usage
 

--- a/docs/SETUP_COMPLETE.md
+++ b/docs/SETUP_COMPLETE.md
@@ -22,7 +22,9 @@
 /api/applications/[id]   - GET/PUT/DELETE - Individual applications
 /api/documents/upload    - POST - Document upload
 /api/notifications/send  - POST - Send notifications
-/api/analytics/metrics   - GET - System analytics
+/api/analytics?action=metrics             - GET - System analytics
+/api/analytics?action=predictive-dashboard - GET - Predictive insights
+/api/analytics?action=telemetry           - GET/POST - Telemetry management
 ```
 
 ### Frontend Integration

--- a/docs/TELEMETRY_RETENTION.md
+++ b/docs/TELEMETRY_RETENTION.md
@@ -1,11 +1,11 @@
 # Telemetry Retention & Aggregation Strategy
 
-MIHAS now captures client and service telemetry in the `api_telemetry` Supabase table via the `/api/analytics/telemetry` endpoint. Metrics are written in small background batches so that HTTP response handling stays fast while telemetry is persisted for long-term analysis.
+MIHAS now captures client and service telemetry in the `api_telemetry` Supabase table via the `/api/analytics?action=telemetry` endpoint. Metrics are written in small background batches so that HTTP response handling stays fast while telemetry is persisted for long-term analysis.
 
 ## Ingestion Pipeline
 
 1. **Client instrumentation** – `MonitoringService` buffers API latency, error, and custom metrics and writes them to a background queue without blocking active requests.
-2. **Batch flush** – The queue is flushed every 5 seconds (or sooner on failures) to `/api/analytics/telemetry`. Errors trigger exponential backoff and pending batches are cached so data is not lost on reloads or process restarts.
+2. **Batch flush** – The queue is flushed every 5 seconds (or sooner on failures) to `/api/analytics?action=telemetry`. Errors trigger exponential backoff and pending batches are cached so data is not lost on reloads or process restarts.
 3. **Server persistence** – The Vercel function validates payloads, enforces rate limits, and stores the events in `api_telemetry`. Aggregated summaries are returned to admins on GET requests.
 
 ## Storage Model
@@ -33,7 +33,7 @@ Indexes on `(service, endpoint)`, `occurred_at`, and `type` keep analytics queri
 ## Operational Notes
 
 - Telemetry flushes continue when the browser tab is backgrounded; pending batches are persisted to storage so they survive process restarts.
-- GET `/api/analytics/telemetry` is admin-only and rate-limited to protect Supabase. POST ingestion is similarly rate-limited to mitigate noisy clients.
+- GET `/api/analytics?action=telemetry` is admin-only and rate-limited to protect Supabase. POST ingestion is similarly rate-limited to mitigate noisy clients.
 - The retention function can be tuned per-environment if a longer history is required. Consider exporting older data to cold storage before changing the retention window.
 
 This strategy keeps granular request telemetry available for at least three months, provides immediate health summaries for dashboards, and supplies stable signals for autoscaling and alert automation.

--- a/src/lib/monitoring.ts
+++ b/src/lib/monitoring.ts
@@ -207,7 +207,7 @@ class HttpTelemetrySink implements TelemetrySink {
       return
     }
 
-    const response = await fetch(`${this.baseUrl}/api/analytics/telemetry`, {
+    const response = await fetch(`${this.baseUrl}/api/analytics?action=telemetry`, {
       method: 'POST',
       headers: await this.buildHeaders(),
       body: JSON.stringify({ events }),
@@ -222,6 +222,7 @@ class HttpTelemetrySink implements TelemetrySink {
 
   async query(query: TelemetryQuery = {}): Promise<TelemetryQueryResult> {
     const params = new URLSearchParams()
+    params.set('action', 'telemetry')
     if (query.service) params.set('service', query.service)
     if (query.endpoint) params.set('endpoint', query.endpoint)
     if (query.type) params.set('type', query.type)
@@ -230,7 +231,7 @@ class HttpTelemetrySink implements TelemetrySink {
     if (query.since) params.set('since', query.since)
     if (query.windowMinutes) params.set('windowMinutes', String(query.windowMinutes))
 
-    const url = `${this.baseUrl}/api/analytics/telemetry${params.size > 0 ? `?${params.toString()}` : ''}`
+    const url = `${this.baseUrl}/api/analytics?${params.toString()}`
     const response = await fetch(url, {
       method: 'GET',
       headers: await this.buildHeaders()

--- a/src/lib/predictiveDashboardApi.ts
+++ b/src/lib/predictiveDashboardApi.ts
@@ -43,7 +43,7 @@ export async function fetchPredictiveDashboardMetrics(): Promise<PredictiveDashb
       return null
     }
 
-    const response = await fetch('/api/analytics/predictive-dashboard', {
+    const response = await fetch('/api/analytics?action=predictive-dashboard', {
       headers: {
         'Authorization': `Bearer ${accessToken}`
       }

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -4,7 +4,9 @@ type QueryValue = string | number | boolean | Array<string | number> | undefined
 type TelemetryQueryParams = Record<string, QueryValue>
 
 export const analyticsService = {
-  getMetrics: () => apiClient.request('/api/analytics/metrics'),
+  getMetrics: () => apiClient.request(`/api/analytics${buildQueryString({ action: 'metrics' })}`),
   getTelemetrySummary: (params: TelemetryQueryParams = {}) =>
-    apiClient.request(`/api/analytics/telemetry${buildQueryString(params)}`)
+    apiClient.request(
+      `/api/analytics${buildQueryString({ action: 'telemetry', ...params })}`
+    )
 }

--- a/test-production-services.js
+++ b/test-production-services.js
@@ -56,7 +56,7 @@ async function testServices() {
   // Test Analytics Service
   console.log('5. Testing Analytics Service...')
   try {
-    const analyticsResponse = await fetch(`${PRODUCTION_URL}/api/analytics/metrics`)
+    const analyticsResponse = await fetch(`${PRODUCTION_URL}/api/analytics?action=metrics`)
     console.log(`   Analytics Service: ${analyticsResponse.status} ${analyticsResponse.statusText}`)
   } catch (error) {
     console.log(`   Analytics Service: ERROR - ${error.message}`)

--- a/test-services-curl.sh
+++ b/test-services-curl.sh
@@ -29,7 +29,7 @@ curl -s -o /dev/null -w "   Notifications Service: %{http_code} %{url_effective}
 
 echo "5. Testing Analytics Service..."
 curl -s -o /dev/null -w "   Analytics Service: %{http_code} %{url_effective}\n" \
-  "$PRODUCTION_URL/api/analytics/metrics"
+  "$PRODUCTION_URL/api/analytics?action=metrics"
 
 echo ""
 echo "✅ Service testing complete!"

--- a/tests/integration/api-services.spec.ts
+++ b/tests/integration/api-services.spec.ts
@@ -22,7 +22,7 @@ test.describe('Microservices API Tests', () => {
   })
 
   test('Analytics service - metrics endpoint', async ({ request }) => {
-    const response = await request.get(`${API_BASE}/api/analytics/metrics`)
+    const response = await request.get(`${API_BASE}/api/analytics?action=metrics`)
     expect(response.status()).toBe(401)
   })
 


### PR DESCRIPTION
## Summary
- add a unified `/api/analytics` handler that dispatches requests by the `action` query parameter
- extract the metrics, predictive dashboard, and telemetry logic into reusable helpers under `api/_lib/analytics`
- update service clients, scripts, tests, and documentation to use the new query-based analytics contract

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*
- npm run test:api *(fails: Playwright cannot reach http://localhost:3000 when the API server is not running)*

------
https://chatgpt.com/codex/tasks/task_e_68cd138f06a883328110834cc7c2bce1