### PR TITLE
refactor: centralize admin user helpers

### DIFF
--- a/api/_lib/adminUserHelpers.js
+++ b/api/_lib/adminUserHelpers.js
@@ -1,4 +1,4 @@
-const { supabaseAdminClient } = require('../../_lib/supabaseClient')
+const { supabaseAdminClient } = require('./supabaseClient')
 
 async function fetchUserProfile(userId) {
   const { data, error } = await supabaseAdminClient

--- a/api/admin/users/[id].js
+++ b/api/admin/users/[id].js
@@ -11,7 +11,7 @@ const {
   parseAction,
   parseRequestBody,
   updateAuthUserMetadata
-} = require('./userHelpers')
+} = require('../../_lib/adminUserHelpers')
 
 module.exports = async function handler(req, res) {
   try {

--- a/api/admin/users/index.js
+++ b/api/admin/users/index.js
@@ -1,5 +1,5 @@
 const { supabaseAdminClient, requireUser } = require('../../_lib/supabaseClient')
-const { fetchUserProfile, fetchActiveRole, parseUserId, parseAction } = require('./userHelpers')
+const { fetchUserProfile, fetchActiveRole, parseUserId, parseAction } = require('../../_lib/adminUserHelpers')
 
 module.exports = async function handler(req, res) {
   try {

--- a/tests/unit/api/admin-users-id.test.ts
+++ b/tests/unit/api/admin-users-id.test.ts
@@ -4,10 +4,10 @@ import type { MockInstance } from 'vitest'
 
 const nodeRequire = createRequire(import.meta.url)
 const supabaseModulePath = nodeRequire.resolve('../../../api/_lib/supabaseClient.js')
-const helperModulePath = nodeRequire.resolve('../../../api/admin/users/userHelpers.js')
+const helperModulePath = nodeRequire.resolve('../../../api/_lib/adminUserHelpers.js')
 const handlerModulePath = nodeRequire.resolve('../../../api/admin/users/[id].js')
 
-type HelperModule = typeof import('../../../api/admin/users/userHelpers.js')
+type HelperModule = typeof import('../../../api/_lib/adminUserHelpers.js')
 
 interface TestRequest {
   method: string
@@ -87,7 +87,7 @@ function mockSupabaseModule() {
 async function loadHandler(
   configureHelpers?: (stubs: HelperModule, actual: HelperModule) => void
 ) {
-  const actualHelpers = await import('../../../api/admin/users/userHelpers.js')
+  const actualHelpers = await import('../../../api/_lib/adminUserHelpers.js')
   const stubHelpers: HelperModule = {
     fetchUserProfile: actualHelpers.fetchUserProfile,
     fetchActiveRole: actualHelpers.fetchActiveRole,


### PR DESCRIPTION
## Summary
- move the admin user helper utilities into the shared api/_lib directory
- update the admin user API routes to import helpers from the new location
- align the admin user unit test helper resolution with the relocated module

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd17bff6dc8332877f8b6a5ae0fc2b