### PR TITLE
Add Speed Insights reporting to forward web vitals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "tailwindcss-animate": "^1.0.7",
         "tesseract.js": "^6.0.1",
         "typescript": "^5.5.3",
+        "web-vitals": "^5.1.0",
         "xlsx": "^0.18.5",
         "zod": "^3.23.8",
         "zustand": "^4.5.5"
@@ -5754,6 +5755,13 @@
       "dependencies": {
         "web-vitals": "0.2.4"
       }
+    },
+    "node_modules/@vercel/gatsby-plugin-vercel-analytics/node_modules/web-vitals": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-0.2.4.tgz",
+      "integrity": "sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@vercel/gatsby-plugin-vercel-builder": {
       "version": "2.0.95",
@@ -15026,10 +15034,10 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-0.2.4.tgz",
-      "integrity": "sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg==",
-      "dev": true
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.1.0.tgz",
+      "integrity": "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "tailwindcss-animate": "^1.0.7",
     "tesseract.js": "^6.0.1",
     "typescript": "^5.5.3",
+    "web-vitals": "^5.1.0",
     "xlsx": "^0.18.5",
     "zod": "^3.23.8",
     "zustand": "^4.5.5"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,94 @@
+import { useCallback, useEffect, useRef, type ComponentType } from 'react'
 import { createRoot } from 'react-dom/client'
+import { SpeedInsights } from '@vercel/speed-insights/react'
+import type { Metric } from 'web-vitals'
 import App from './App.tsx'
 import './index.css'
+import { AnalyticsService } from './lib/analytics.ts'
+
+type BaseSpeedInsightsProps = Parameters<typeof SpeedInsights>[0]
+type WebVitalsMetric = Metric & { path?: string; url?: string }
+const InstrumentedSpeedInsights = SpeedInsights as unknown as ComponentType<BaseSpeedInsightsProps & { onReport?: (metric: WebVitalsMetric) => void }>
+
+const SpeedInsightsReporter = () => {
+  const reportedMetrics = useRef(new Set<string>())
+
+  const handleReport = useCallback((metric: WebVitalsMetric) => {
+    const metricKey = `${metric.name}-${metric.id}`
+    if (reportedMetrics.current.has(metricKey)) {
+      return
+    }
+
+    reportedMetrics.current.add(metricKey)
+
+    const metadata = {
+      id: metric.id,
+      name: metric.name,
+      value: metric.value,
+      delta: metric.delta,
+      rating: metric.rating,
+      navigationType: metric.navigationType,
+      ...(metric.path ? { path: metric.path } : {}),
+      ...(metric.url ? { url: metric.url } : {}),
+      ...(metric.attribution ? { attribution: metric.attribution } : {})
+    }
+
+    void AnalyticsService.trackEvent({
+      action_type: 'web_vitals',
+      page_path: metric.path ?? (typeof window !== 'undefined' ? window.location.pathname : '/'),
+      metadata: {
+        metric: metadata
+      }
+    })
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const handleCustomEvent = (event: Event) => {
+      const detail = (event as CustomEvent<WebVitalsMetric>).detail
+      if (detail) {
+        handleReport(detail)
+      }
+    }
+
+    window.addEventListener('vercel-speed-insights:core-web-vital', handleCustomEvent as EventListener)
+    window.addEventListener('vercel-speed-insights:report', handleCustomEvent as EventListener)
+
+    return () => {
+      window.removeEventListener('vercel-speed-insights:core-web-vital', handleCustomEvent as EventListener)
+      window.removeEventListener('vercel-speed-insights:report', handleCustomEvent as EventListener)
+    }
+  }, [handleReport])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    void import('web-vitals').then(({ onCLS, onFID, onINP, onLCP, onTTFB }) => {
+      onCLS(handleReport)
+      onFID(handleReport)
+      onINP(handleReport)
+      onLCP(handleReport)
+      onTTFB(handleReport)
+    }).catch((error) => {
+      console.error('Failed to load web-vitals metrics', error)
+    })
+  }, [handleReport])
+
+  return <InstrumentedSpeedInsights onReport={handleReport} />
+}
 
 // Render immediately for better performance
-createRoot(document.getElementById('root')!).render(<App />)
+createRoot(document.getElementById('root')!).render(
+  <>
+    <App />
+    <SpeedInsightsReporter />
+  </>
+)
 
 // Defer non-critical services
 if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
- render a dedicated SpeedInsightsReporter next to App so Vercel instrumentation boots at startup and forwards Core Web Vitals to AnalyticsService
- capture web-vitals metrics and Vercel custom events, deduplicating reports before tracking them as `web_vitals` actions
- add the web-vitals dependency needed to collect the metrics payloads for analytics metadata

## Testing
- npm run build *(fails: react-window VariableSizeList export missing in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68cd22ba02e08332a7b623399b375a01