### PR TITLE
Integrate analytics tracker with router

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ import { AdminRoute } from '@/components/AdminRoute'
 import { ToastProvider } from '@/components/ui/Toast'
 import { LoadingFallback } from '@/components/ui/LoadingFallback'
 import { routes, type RouteConfig } from '@/routes/config'
+import { AnalyticsTracker } from '@/components/analytics/AnalyticsTracker'
+import { Analytics } from '@vercel/analytics/react'
 
 
 // Optimized query client for better performance
@@ -55,17 +57,20 @@ function App() {
       <AuthProvider>
         <ToastProvider>
           <Router>
-            <div className="min-h-screen bg-gray-50">
-              <Routes>
-                {routes.map((route) => (
-                  <Route
-                    key={route.path}
-                    path={route.path}
-                    element={renderRoute(route)}
-                  />
-                ))}
-              </Routes>
-            </div>
+            <AnalyticsTracker>
+              <div className="min-h-screen bg-gray-50">
+                <Routes>
+                  {routes.map((route) => (
+                    <Route
+                      key={route.path}
+                      path={route.path}
+                      element={renderRoute(route)}
+                    />
+                  ))}
+                </Routes>
+              </div>
+            </AnalyticsTracker>
+            <Analytics />
           </Router>
 
         </ToastProvider>

--- a/src/components/analytics/AnalyticsTracker.tsx
+++ b/src/components/analytics/AnalyticsTracker.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 import { useLocation } from 'react-router-dom'
 import { useAnalytics } from '@/hooks/useAnalytics'
 
@@ -9,8 +9,14 @@ interface AnalyticsTrackerProps {
 export function AnalyticsTracker({ children }: AnalyticsTrackerProps) {
   const location = useLocation()
   const { trackPageView } = useAnalytics()
+  const hasTrackedInitialView = useRef(false)
 
   useEffect(() => {
+    if (!hasTrackedInitialView.current) {
+      hasTrackedInitialView.current = true
+      return
+    }
+
     // Track page view on route change
     trackPageView(location.pathname)
   }, [location.pathname, trackPageView])


### PR DESCRIPTION
## Summary
- wrap the router content with AnalyticsTracker so route changes trigger page view tracking
- import and render Vercel Analytics alongside the tracker for analytics reporting
- guard AnalyticsTracker's effect with a ref to avoid double-counting the initial page load

## Testing
- `npm run lint` *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cd25c63dd483329341810eeb79d1e6