### PR TITLE
Harden document upload validation

### DIFF
--- a/api/documents/upload.js
+++ b/api/documents/upload.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const { supabaseAdminClient, getUserFromRequest } = require('../_lib/supabaseClient')
 const {
   checkRateLimit,
@@ -5,6 +6,186 @@ const {
   getLimiterConfig,
   attachRateLimitHeaders
 } = require('../_lib/rateLimiter')
+
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024 // 10MB
+const ALLOWED_EXTENSIONS = new Set(['pdf', 'png', 'jpg', 'jpeg'])
+const EXTENSION_MIME_MAP = {
+  pdf: ['application/pdf'],
+  png: ['image/png'],
+  jpg: ['image/jpeg'],
+  jpeg: ['image/jpeg']
+}
+const ALLOWED_MIME_TYPES = new Set(
+  Object.values(EXTENSION_MIME_MAP).flatMap((mimes) => mimes.map((mime) => mime.toLowerCase()))
+)
+
+const ENABLE_MALWARE_SCAN = process.env.ENABLE_MALWARE_SCAN === 'true'
+const MALWARE_SIGNATURES = [
+  Buffer.from('X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*')
+]
+
+const BASE64_REGEX = /^[A-Za-z0-9+/=]+$/
+
+function respondWithError(res, statusCode, message) {
+  return res.status(statusCode).json({ error: message })
+}
+
+function sanitizeStorageSegment(value, fieldName) {
+  if (!value) {
+    return { error: `Invalid ${fieldName}` }
+  }
+
+  const normalized = String(value)
+    .trim()
+    .replace(/[^a-zA-Z0-9_-]/g, '')
+
+  if (!normalized) {
+    return { error: `Invalid ${fieldName}` }
+  }
+
+  return { value: normalized }
+}
+
+function normalizeFileName(fileName) {
+  if (!fileName || typeof fileName !== 'string') {
+    return { error: 'Invalid file name' }
+  }
+
+  const trimmed = fileName.trim()
+  const baseName = path.posix.basename(trimmed)
+
+  if (!baseName || baseName === '.' || baseName === '..' || baseName.includes('\0')) {
+    return { error: 'Invalid file name' }
+  }
+
+  const lastDotIndex = baseName.lastIndexOf('.')
+  if (lastDotIndex === -1) {
+    return { error: 'File name must include an extension' }
+  }
+
+  const namePart = baseName.slice(0, lastDotIndex)
+  const extension = baseName.slice(lastDotIndex + 1).toLowerCase()
+
+  if (!ALLOWED_EXTENSIONS.has(extension)) {
+    return { error: 'File type is not allowed' }
+  }
+
+  const sanitizedName = namePart
+    .replace(/[^a-zA-Z0-9_-]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 150)
+
+  const safeName = sanitizedName || 'document'
+  const normalizedFileName = `${safeName}.${extension}`
+
+  if (!normalizedFileName || normalizedFileName.startsWith('.')) {
+    return { error: 'Invalid file name' }
+  }
+
+  return { fileName: normalizedFileName, extension }
+}
+
+function decodeBase64Payload(base64String, extension, declaredMimeType, declaredSize) {
+  if (!base64String || typeof base64String !== 'string') {
+    return { error: 'Invalid file data payload' }
+  }
+
+  const sanitizedBase64 = base64String.replace(/\s+/g, '')
+
+  if (sanitizedBase64.length % 4 !== 0 || !BASE64_REGEX.test(sanitizedBase64)) {
+    return { error: 'Invalid file data encoding' }
+  }
+
+  let buffer
+  try {
+    buffer = Buffer.from(sanitizedBase64, 'base64')
+  } catch (error) {
+    return { error: 'Invalid file data encoding' }
+  }
+
+  if (!buffer || buffer.length === 0) {
+    return { error: 'File data is empty' }
+  }
+
+  if (Number.isFinite(declaredSize) && declaredSize !== buffer.length) {
+    return { error: 'File data size mismatch' }
+  }
+
+  const extensionMimeTypes = EXTENSION_MIME_MAP[extension] ?? []
+  const normalizedDeclaredMime = declaredMimeType?.toLowerCase()
+
+  if (normalizedDeclaredMime && !extensionMimeTypes.includes(normalizedDeclaredMime)) {
+    return { error: 'File type does not match the provided content-type' }
+  }
+
+  const resolvedMimeType = normalizedDeclaredMime || extensionMimeTypes[0]
+
+  if (!resolvedMimeType || !ALLOWED_MIME_TYPES.has(resolvedMimeType)) {
+    return { error: 'File type is not allowed' }
+  }
+
+  return {
+    buffer,
+    size: buffer.length,
+    mimeType: resolvedMimeType
+  }
+}
+
+function decodeFileData(fileData, extension) {
+  if (!fileData) {
+    return { error: 'Missing file data' }
+  }
+
+  if (typeof fileData === 'string') {
+    const trimmed = fileData.trim()
+    const dataUrlMatch = trimmed.match(/^data:([^;]+);base64,(.+)$/i)
+
+    if (dataUrlMatch) {
+      const [, mimeType, base64Content] = dataUrlMatch
+      return decodeBase64Payload(base64Content, extension, mimeType, undefined)
+    }
+
+    return decodeBase64Payload(trimmed, extension, undefined, undefined)
+  }
+
+  if (typeof fileData === 'object') {
+    const base64Content =
+      typeof fileData.base64 === 'string'
+        ? fileData.base64
+        : typeof fileData.data === 'string'
+          ? fileData.data
+          : typeof fileData.content === 'string'
+            ? fileData.content
+            : undefined
+
+    const declaredMimeType = typeof fileData.mimeType === 'string' ? fileData.mimeType : undefined
+    const declaredSize =
+      typeof fileData.size === 'number'
+        ? fileData.size
+        : typeof fileData.size === 'string'
+          ? Number.parseInt(fileData.size, 10)
+          : undefined
+
+    return decodeBase64Payload(base64Content, extension, declaredMimeType, declaredSize)
+  }
+
+  return { error: 'Invalid file data payload' }
+}
+
+async function scanForMalware(buffer) {
+  if (!ENABLE_MALWARE_SCAN) {
+    return { clean: true }
+  }
+
+  for (const signature of MALWARE_SIGNATURES) {
+    if (buffer.includes(signature)) {
+      return { clean: false, error: 'Malicious content detected in the uploaded file' }
+    }
+  }
+
+  return { clean: true }
+}
 
 module.exports = async function handler(req, res) {
   if (req.method !== 'POST') {
@@ -39,6 +220,25 @@ module.exports = async function handler(req, res) {
       return res.status(400).json({ error: 'Missing required document fields' })
     }
 
+    const normalizedFileNameResult = normalizeFileName(fileName)
+    if (normalizedFileNameResult.error) {
+      return respondWithError(res, 400, normalizedFileNameResult.error)
+    }
+
+    const decodedFile = decodeFileData(fileData, normalizedFileNameResult.extension)
+    if (decodedFile.error) {
+      return respondWithError(res, 400, decodedFile.error)
+    }
+
+    if (decodedFile.size > MAX_FILE_SIZE_BYTES) {
+      return respondWithError(res, 413, 'File exceeds the maximum allowed size of 10MB')
+    }
+
+    const malwareResult = await scanForMalware(decodedFile.buffer)
+    if (!malwareResult.clean) {
+      return respondWithError(res, 400, malwareResult.error || 'Malicious content detected')
+    }
+
     const { data: application, error: applicationError } = await supabaseAdminClient
       .from('applications_new')
       .select('id, user_id')
@@ -57,10 +257,28 @@ module.exports = async function handler(req, res) {
       return res.status(403).json({ error: 'Access denied' })
     }
 
-    const filePath = `${application.user_id}/${applicationId}/${fileName}`
+    const sanitizedUserIdResult = sanitizeStorageSegment(application.user_id, 'user identifier')
+    if (sanitizedUserIdResult.error) {
+      return respondWithError(res, 400, sanitizedUserIdResult.error)
+    }
+
+    const sanitizedApplicationIdResult = sanitizeStorageSegment(applicationId, 'application identifier')
+    if (sanitizedApplicationIdResult.error) {
+      return respondWithError(res, 400, sanitizedApplicationIdResult.error)
+    }
+
+    const filePath = path.posix.join(
+      sanitizedUserIdResult.value,
+      sanitizedApplicationIdResult.value,
+      normalizedFileNameResult.fileName
+    )
     const { data: uploadData, error: uploadError } = await supabaseAdminClient.storage
       .from('documents')
-      .upload(filePath, fileData)
+      .upload(filePath, decodedFile.buffer, {
+        contentType: decodedFile.mimeType,
+        upsert: false,
+        cacheControl: '3600'
+      })
 
     if (uploadError) {
       return res.status(400).json({ error: uploadError.message })
@@ -71,7 +289,7 @@ module.exports = async function handler(req, res) {
       .insert({
         application_id: applicationId,
         document_type: documentType,
-        document_name: fileName,
+        document_name: normalizedFileNameResult.fileName,
         file_url: uploadData.path,
         system_generated: false,
         verification_status: 'pending'

--- a/tests/unit/api/documents/upload.test.ts
+++ b/tests/unit/api/documents/upload.test.ts
@@ -1,0 +1,132 @@
+import { createRequire } from 'module'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+process.env.VITE_SUPABASE_URL = process.env.VITE_SUPABASE_URL ?? 'https://example.supabase.co'
+process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? 'service-role-key'
+
+const require = createRequire(import.meta.url)
+
+const storageUploadMock = vi.fn()
+const storageFromMock = vi.fn(() => ({ upload: storageUploadMock }))
+const fromMock = vi.fn()
+const getUserFromRequestMock = vi.fn()
+
+const supabaseModule = require('../../../../api/_lib/supabaseClient.js')
+const supabaseAdminClientStub = {
+  storage: {
+    from: storageFromMock
+  },
+  from: (...args: any[]) => fromMock(...args)
+}
+supabaseModule.supabaseAdminClient = supabaseAdminClientStub
+supabaseModule.getUserFromRequest = getUserFromRequestMock
+
+const rateLimiterModule = require('../../../../api/_lib/rateLimiter.js')
+rateLimiterModule.setRateLimiterStore(rateLimiterModule.createInMemoryFallbackStore())
+
+const handler = require('../../../../api/documents/upload.js')
+
+const BASE_REQUEST_BODY = {
+  fileName: 'transcript.pdf',
+  fileData: `data:application/pdf;base64,${Buffer.from('%PDF-1.4 test document').toString('base64')}`,
+  documentType: 'transcript',
+  applicationId: 'app-123'
+}
+
+const createRequest = (overrides: Partial<{ method: string; headers: Record<string, string>; body: any }> = {}) => {
+  const baseRequest = {
+    method: 'POST',
+    headers: {
+      authorization: 'Bearer fake-token'
+    },
+    body: { ...BASE_REQUEST_BODY }
+  }
+
+  return {
+    ...baseRequest,
+    ...overrides,
+    headers: {
+      ...baseRequest.headers,
+      ...(overrides.headers ?? {})
+    },
+    body: {
+      ...baseRequest.body,
+      ...(overrides.body ?? {})
+    }
+  }
+}
+
+const createResponse = () => {
+  return {
+    statusCode: 200,
+    payload: undefined as any,
+    status(code: number) {
+      this.statusCode = code
+      return this
+    },
+    json(data: any) {
+      this.payload = data
+      return this
+    }
+  }
+}
+
+beforeEach(() => {
+  storageUploadMock.mockReset()
+  storageFromMock.mockReset()
+  storageFromMock.mockReturnValue({ upload: storageUploadMock })
+  fromMock.mockReset()
+  getUserFromRequestMock.mockReset()
+  getUserFromRequestMock.mockResolvedValue({ user: { id: 'user-123' }, isAdmin: false })
+})
+
+describe('documents upload handler validation', () => {
+  it('rejects disallowed file extensions before touching storage', async () => {
+    const req = createRequest({
+      body: {
+        fileName: 'malware.exe'
+      }
+    })
+    const res = createResponse()
+
+    await handler(req, res)
+
+    expect(res.statusCode).toBe(400)
+    expect(res.payload).toEqual({ error: 'File type is not allowed' })
+    expect(storageFromMock).not.toHaveBeenCalled()
+    expect(fromMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects uploads that exceed the configured size limit', async () => {
+    const largeBuffer = Buffer.alloc(10 * 1024 * 1024 + 1)
+    const req = createRequest({
+      body: {
+        fileData: `data:application/pdf;base64,${largeBuffer.toString('base64')}`
+      }
+    })
+    const res = createResponse()
+
+    await handler(req, res)
+
+    expect(res.statusCode).toBe(413)
+    expect(res.payload).toEqual({ error: 'File exceeds the maximum allowed size of 10MB' })
+    expect(storageFromMock).not.toHaveBeenCalled()
+    expect(fromMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects tampered or malformed base64 payloads', async () => {
+    const req = createRequest({
+      body: {
+        fileData: 'data:application/pdf;base64,@@@'
+      }
+    })
+    const res = createResponse()
+
+    await handler(req, res)
+
+    expect(res.statusCode).toBe(400)
+    expect(res.payload).toEqual({ error: 'Invalid file data encoding' })
+    expect(storageFromMock).not.toHaveBeenCalled()
+    expect(fromMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- normalize uploaded document file names, validate extensions, and decode payloads securely before writing to storage
- enforce content type and size limits, optionally run malware signatures, and sanitize storage paths prior to Supabase writes
- add vitest coverage for disallowed, oversized, and malformed uploads to guard against regressions

## Testing
- npx vitest run tests/unit/api/documents/upload.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cd2985e8ec8332812ce99e7598060e