### PR TITLE
feat: add consent-aware multi-channel notifications

### DIFF
--- a/api/notifications.js
+++ b/api/notifications.js
@@ -1,3 +1,5 @@
+const fetch = require('node-fetch')
+
 const { supabaseAdminClient, getUserFromRequest } = require('./_lib/supabaseClient')
 const {
   checkRateLimit,
@@ -6,15 +8,31 @@ const {
   attachRateLimitHeaders
 } = require('./_lib/rateLimiter')
 
+const TWILIO_ACCOUNT_SID = process.env.TWILIO_ACCOUNT_SID
+const TWILIO_AUTH_TOKEN = process.env.TWILIO_AUTH_TOKEN
+const TWILIO_SMS_FROM = process.env.TWILIO_SMS_FROM
+const TWILIO_SMS_MESSAGING_SERVICE_SID = process.env.TWILIO_SMS_MESSAGING_SERVICE_SID
+const TWILIO_WHATSAPP_FROM = process.env.TWILIO_WHATSAPP_FROM
+
 module.exports = async function handler(req, res) {
+  if (req.method === 'GET') {
+    const { action } = req.query
+
+    if (action === 'preferences') {
+      return handleGetPreferences(req, res)
+    }
+
+    return res.status(400).json({ error: 'Invalid action for GET requests' })
+  }
+
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' })
   }
 
   const { action } = req.query
 
-  if (!action || !['send', 'application-submitted'].includes(action)) {
-    return res.status(400).json({ error: 'Invalid action. Use: send or application-submitted' })
+  if (!action || !['send', 'application-submitted', 'dispatch-channel', 'update-consent'].includes(action)) {
+    return res.status(400).json({ error: 'Invalid action. Use: send, application-submitted, dispatch-channel or update-consent' })
   }
 
   try {
@@ -36,9 +54,13 @@ module.exports = async function handler(req, res) {
   try {
     switch (action) {
       case 'send':
-        return await handleSendNotification(req, res)
+        return handleSendNotification(req, res)
       case 'application-submitted':
-        return await handleApplicationSubmitted(req, res)
+        return handleApplicationSubmitted(req, res)
+      case 'dispatch-channel':
+        return handleDispatchChannel(req, res)
+      case 'update-consent':
+        return handleUpdateConsent(req, res)
       default:
         return res.status(400).json({ error: 'Invalid action' })
     }
@@ -135,8 +157,8 @@ async function handleApplicationSubmitted(req, res) {
       sent_at: new Date().toISOString()
     })
 
-  return res.status(201).json({ 
-    success: true, 
+  return res.status(201).json({
+    success: true,
     notification,
     application: {
       number: application.application_number,
@@ -145,4 +167,430 @@ async function handleApplicationSubmitted(req, res) {
       institution: application.institution
     }
   })
+}
+
+async function handleGetPreferences(req, res) {
+  const authContext = await getUserFromRequest(req)
+  if (authContext.error) {
+    return res.status(403).json({ error: authContext.error })
+  }
+
+  try {
+    const preferences = await fetchUserNotificationPreferences(authContext.user.id)
+    const { data: profile, error: profileError } = await supabaseAdminClient
+      .from('user_profiles')
+      .select('phone')
+      .eq('user_id', authContext.user.id)
+      .maybeSingle()
+
+    if (profileError) {
+      throw new Error(profileError.message)
+    }
+
+    return res.status(200).json({ ...preferences, phone: profile?.phone ?? null })
+  } catch (error) {
+    console.error('Failed to load notification preferences:', error)
+    return res.status(500).json({ error: 'Failed to load notification preferences' })
+  }
+}
+
+async function handleUpdateConsent(req, res) {
+  const authContext = await getUserFromRequest(req)
+  if (authContext.error) {
+    return res.status(403).json({ error: authContext.error })
+  }
+
+  const { channel, action, source, reason } = req.body || {}
+  const normalizedChannel = typeof channel === 'string' ? channel.toLowerCase() : ''
+
+  if (!['sms', 'whatsapp'].includes(normalizedChannel)) {
+    return res.status(400).json({ error: 'Unsupported channel. Allowed values: sms, whatsapp' })
+  }
+
+  if (!['opt_in', 'opt_out'].includes(action)) {
+    return res.status(400).json({ error: 'Invalid action. Use opt_in or opt_out' })
+  }
+
+  try {
+    const existing = await fetchUserNotificationPreferences(authContext.user.id)
+    const nextEnabled = action === 'opt_in'
+    const nowIso = new Date().toISOString()
+    const consentSource = typeof source === 'string' && source.trim() ? source.trim() : 'student_settings_page'
+    const channelKey = normalizedChannel === 'sms' ? 'sms' : 'whatsapp'
+
+    const updatedChannels = updateChannelEnabledState(existing.channels, normalizedChannel, nextEnabled)
+
+    const payload = {
+      ...existing,
+      user_id: authContext.user.id,
+      channels: updatedChannels,
+      [`${channelKey}_opt_in_actor`]: action === 'opt_in' ? authContext.user.id : existing[`${channelKey}_opt_in_actor`] ?? null,
+      [`${channelKey}_opt_in_source`]: action === 'opt_in' ? consentSource : existing[`${channelKey}_opt_in_source`] ?? null,
+      [`${channelKey}_opt_in_at`]: action === 'opt_in' ? nowIso : existing[`${channelKey}_opt_in_at`] ?? null,
+      [`${channelKey}_opt_out_at`]: action === 'opt_out' ? nowIso : null,
+      [`${channelKey}_opt_out_source`]: action === 'opt_out' ? consentSource : null,
+      [`${channelKey}_opt_out_actor`]: action === 'opt_out' ? authContext.user.id : null,
+      [`${channelKey}_opt_out_reason`]: action === 'opt_out' ? (typeof reason === 'string' ? reason : null) : null
+    }
+
+    const { data, error } = await supabaseAdminClient
+      .from('user_notification_preferences')
+      .upsert(payload, { onConflict: 'user_id' })
+      .select('*')
+      .single()
+
+    if (error) {
+      throw new Error(error.message)
+    }
+
+    const normalized = normalizePreferencesRecord(data)
+
+    return res.status(200).json(normalized)
+  } catch (error) {
+    console.error('Failed to update notification consent:', error)
+    return res.status(500).json({ error: 'Failed to update notification consent' })
+  }
+}
+
+async function handleDispatchChannel(req, res) {
+  const authContext = await getUserFromRequest(req, { requireAdmin: true })
+  if (authContext.error) {
+    return res.status(403).json({ error: authContext.error })
+  }
+
+  const { userId, channel, content, type, metadata } = req.body || {}
+  const normalizedChannel = typeof channel === 'string' ? channel.toLowerCase() : ''
+
+  if (!userId || !content || !type || !normalizedChannel) {
+    return res.status(400).json({ error: 'userId, type, channel and content are required' })
+  }
+
+  if (!['sms', 'whatsapp'].includes(normalizedChannel)) {
+    return res.status(400).json({ error: 'Unsupported channel. Allowed values: sms, whatsapp' })
+  }
+
+  try {
+    ensureTwilioConfiguration(normalizedChannel)
+  } catch (configError) {
+    console.error('Twilio configuration error:', configError)
+    return res.status(503).json({ error: configError.message })
+  }
+
+  try {
+    const preferences = await fetchUserNotificationPreferences(userId)
+
+    if (!hasExplicitOptIn(preferences, normalizedChannel)) {
+      await logChannelDelivery({
+        userId,
+        type,
+        channel: normalizedChannel,
+        success: false,
+        status: 'blocked'
+      })
+
+      return res.status(412).json({ error: 'Channel disabled or missing opt-in consent' })
+    }
+
+    const { data: profile, error: profileError } = await supabaseAdminClient
+      .from('user_profiles')
+      .select('phone')
+      .eq('user_id', userId)
+      .maybeSingle()
+
+    if (profileError) {
+      throw new Error(profileError.message)
+    }
+
+    const formattedRecipient = formatPhoneForChannel(profile?.phone ?? '', normalizedChannel)
+
+    if (!formattedRecipient) {
+      await logChannelDelivery({
+        userId,
+        type,
+        channel: normalizedChannel,
+        success: false,
+        status: 'invalid_destination'
+      })
+
+      return res.status(400).json({ error: 'Valid international phone number is required for this channel' })
+    }
+
+    const twilioResult = await sendTwilioMessage({
+      channel: normalizedChannel,
+      to: formattedRecipient,
+      body: content
+    })
+
+    const messageId = twilioResult.data?.sid || null
+    const providerStatus = twilioResult.data?.status || (twilioResult.ok ? 'sent' : 'failed')
+
+    await logChannelDelivery({
+      userId,
+      type,
+      channel: normalizedChannel,
+      success: twilioResult.ok,
+      status: providerStatus,
+      messageId,
+      metadata
+    })
+
+    if (!twilioResult.ok) {
+      const providerMessage = twilioResult.data?.message || 'Failed to dispatch channel notification'
+      return res.status(502).json({
+        error: providerMessage,
+        status: providerStatus,
+        messageId
+      })
+    }
+
+    return res.status(200).json({
+      success: true,
+      status: providerStatus,
+      messageId,
+      channel: normalizedChannel
+    })
+  } catch (error) {
+    console.error('Channel dispatch error:', error)
+
+    try {
+      await logChannelDelivery({
+        userId,
+        type,
+        channel: normalizedChannel,
+        success: false,
+        status: 'error'
+      })
+    } catch (logError) {
+      console.error('Failed to log channel dispatch error:', logError)
+    }
+
+    return res.status(500).json({ error: 'Failed to dispatch channel notification' })
+  }
+}
+
+async function fetchUserNotificationPreferences(userId) {
+  const record = await fetchUserNotificationPreferencesRecord(userId)
+  return normalizePreferencesRecord(record || { user_id: userId })
+}
+
+async function fetchUserNotificationPreferencesRecord(userId) {
+  const { data, error } = await supabaseAdminClient
+    .from('user_notification_preferences')
+    .select('*')
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  return data || null
+}
+
+function normalizePreferencesRecord(record = {}) {
+  const preferences = ensureAuditFields({ ...record })
+  preferences.channels = normalizeChannelPreferences(preferences.channels)
+  preferences.frequency = preferences.frequency || 'immediate'
+  preferences.optimalTiming = typeof preferences.optimalTiming === 'boolean' ? preferences.optimalTiming : true
+  return preferences
+}
+
+function normalizeChannelPreferences(channels) {
+  const defaultConfig = [
+    { type: 'email', enabled: true, priority: 1 },
+    { type: 'sms', enabled: false, priority: 2 },
+    { type: 'whatsapp', enabled: false, priority: 3 },
+    { type: 'in_app', enabled: true, priority: 4 }
+  ]
+
+  const channelMap = new Map(defaultConfig.map(entry => [entry.type, { ...entry }]))
+
+  if (Array.isArray(channels)) {
+    channels.forEach(entry => {
+      if (!entry || typeof entry !== 'object' || !entry.type) {
+        return
+      }
+
+      const type = String(entry.type)
+      const normalized = {
+        type,
+        enabled: Boolean(entry.enabled),
+        priority: Number.isFinite(entry.priority) ? Number(entry.priority) : channelMap.get(type)?.priority ?? defaultConfig.length + 1
+      }
+
+      channelMap.set(type, { ...channelMap.get(type), ...normalized })
+    })
+  }
+
+  return Array.from(channelMap.values()).sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0))
+}
+
+function updateChannelEnabledState(channels, targetChannel, enabled) {
+  const normalizedChannels = normalizeChannelPreferences(channels)
+  return normalizedChannels.map(entry =>
+    entry.type === targetChannel
+      ? { ...entry, enabled }
+      : entry
+  )
+}
+
+function ensureAuditFields(preferences) {
+  const auditFields = [
+    'sms_opt_in_at',
+    'sms_opt_in_source',
+    'sms_opt_in_actor',
+    'sms_opt_out_at',
+    'sms_opt_out_source',
+    'sms_opt_out_actor',
+    'sms_opt_out_reason',
+    'whatsapp_opt_in_at',
+    'whatsapp_opt_in_source',
+    'whatsapp_opt_in_actor',
+    'whatsapp_opt_out_at',
+    'whatsapp_opt_out_source',
+    'whatsapp_opt_out_actor',
+    'whatsapp_opt_out_reason'
+  ]
+
+  auditFields.forEach(field => {
+    if (!(field in preferences)) {
+      preferences[field] = null
+    }
+  })
+
+  if (!preferences.channels) {
+    preferences.channels = []
+  }
+
+  return preferences
+}
+
+function hasExplicitOptIn(preferences, channel) {
+  const channelEntry = Array.isArray(preferences.channels)
+    ? preferences.channels.find(entry => entry.type === channel)
+    : null
+
+  if (!channelEntry || !channelEntry.enabled) {
+    return false
+  }
+
+  const prefix = channel === 'sms' ? 'sms' : channel === 'whatsapp' ? 'whatsapp' : null
+
+  if (!prefix) {
+    return true
+  }
+
+  const optInAt = preferences[`${prefix}_opt_in_at`]
+  const optOutAt = preferences[`${prefix}_opt_out_at`]
+
+  if (!optInAt) {
+    return false
+  }
+
+  if (optOutAt) {
+    return false
+  }
+
+  return true
+}
+
+function ensureTwilioConfiguration(channel) {
+  if (!TWILIO_ACCOUNT_SID || !TWILIO_AUTH_TOKEN) {
+    throw new Error('Twilio credentials are not configured')
+  }
+
+  if (channel === 'sms' && !TWILIO_SMS_MESSAGING_SERVICE_SID && !TWILIO_SMS_FROM) {
+    throw new Error('Twilio SMS sender configuration is missing')
+  }
+
+  if (channel === 'whatsapp' && !TWILIO_WHATSAPP_FROM) {
+    throw new Error('Twilio WhatsApp sender number is not configured')
+  }
+}
+
+function formatPhoneForChannel(rawPhone, channel) {
+  if (!rawPhone || typeof rawPhone !== 'string') {
+    return null
+  }
+
+  const trimmed = rawPhone.replace(/[\s\-]/g, '')
+
+  if (channel === 'whatsapp') {
+    if (trimmed.startsWith('whatsapp:')) {
+      return trimmed
+    }
+
+    return trimmed.startsWith('+') ? `whatsapp:${trimmed}` : null
+  }
+
+  if (trimmed.startsWith('whatsapp:')) {
+    const stripped = trimmed.replace(/^whatsapp:/, '')
+    return stripped.startsWith('+') ? stripped : null
+  }
+
+  return trimmed.startsWith('+') ? trimmed : null
+}
+
+async function sendTwilioMessage({ channel, to, body }) {
+  const authHeader = Buffer.from(`${TWILIO_ACCOUNT_SID}:${TWILIO_AUTH_TOKEN}`).toString('base64')
+  const url = `https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}/Messages.json`
+
+  const params = new URLSearchParams()
+  params.append('To', to)
+  params.append('Body', body)
+
+  if (channel === 'sms') {
+    if (TWILIO_SMS_MESSAGING_SERVICE_SID) {
+      params.append('MessagingServiceSid', TWILIO_SMS_MESSAGING_SERVICE_SID)
+    } else if (TWILIO_SMS_FROM) {
+      params.append('From', TWILIO_SMS_FROM)
+    }
+  } else if (channel === 'whatsapp') {
+    params.append('From', TWILIO_WHATSAPP_FROM)
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${authHeader}`,
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    body: params.toString()
+  })
+
+  let payload
+
+  try {
+    payload = await response.json()
+  } catch (error) {
+    payload = null
+  }
+
+  return {
+    ok: response.ok,
+    status: response.status,
+    data: payload
+  }
+}
+
+async function logChannelDelivery({ userId, type, channel, success, status, messageId }) {
+  const channelStatuses = { [channel]: status || (success ? 'sent' : 'failed') }
+  const providerMessageIds = messageId ? { [channel]: messageId } : {}
+
+  const { error } = await supabaseAdminClient
+    .from('notification_logs')
+    .insert({
+      user_id: userId,
+      type,
+      channels: [channel],
+      success_count: success ? 1 : 0,
+      total_count: 1,
+      sent_at: new Date().toISOString(),
+      channel_statuses: channelStatuses,
+      provider_message_ids: providerMessageIds
+    })
+
+  if (error) {
+    throw new Error(error.message)
+  }
 }

--- a/src/components/ui/AuthenticatedNavigation.tsx
+++ b/src/components/ui/AuthenticatedNavigation.tsx
@@ -14,7 +14,8 @@ import {
   Menu,
   X,
   Home,
-  Plus
+  Plus,
+  Bell
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
@@ -78,6 +79,7 @@ export function AuthenticatedNavigation({ className }: AuthenticatedNavigationPr
     { href: '/student/dashboard', label: 'Dashboard', icon: Home },
     { href: '/apply', label: 'New Application', icon: Plus },
     { href: '/settings', label: 'Settings', icon: Settings },
+    { href: '/student/notifications', label: 'Notifications', icon: Bell }
   ]
 
   return (

--- a/src/pages/student/NotificationSettings.tsx
+++ b/src/pages/student/NotificationSettings.tsx
@@ -1,0 +1,314 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { motion } from 'framer-motion'
+import { format } from 'date-fns'
+import { AuthenticatedNavigation } from '@/components/ui/AuthenticatedNavigation'
+import { Button } from '@/components/ui/Button'
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
+import { notificationService } from '@/services/notifications'
+import { ArrowLeft, MessageCircle, MessageSquare } from 'lucide-react'
+
+type ChannelKey = 'sms' | 'whatsapp'
+
+interface ChannelPreference {
+  type: string
+  enabled: boolean
+  priority: number
+}
+
+interface NotificationPreferencesResponse {
+  channels: ChannelPreference[]
+  optimalTiming: boolean
+  frequency: string
+  sms_opt_in_at: string | null
+  sms_opt_in_source: string | null
+  sms_opt_in_actor: string | null
+  sms_opt_out_at: string | null
+  sms_opt_out_source: string | null
+  sms_opt_out_actor: string | null
+  sms_opt_out_reason: string | null
+  whatsapp_opt_in_at: string | null
+  whatsapp_opt_in_source: string | null
+  whatsapp_opt_in_actor: string | null
+  whatsapp_opt_out_at: string | null
+  whatsapp_opt_out_source: string | null
+  whatsapp_opt_out_actor: string | null
+  whatsapp_opt_out_reason: string | null
+  phone?: string | null
+}
+
+const CHANNEL_DETAILS: Record<ChannelKey, { title: string; description: string; Icon: React.ComponentType<{ className?: string }> }> = {
+  sms: {
+    title: 'SMS Alerts',
+    description: 'Receive important application updates as text messages directly to your phone.',
+    Icon: MessageSquare
+  },
+  whatsapp: {
+    title: 'WhatsApp Updates',
+    description: 'Get real-time WhatsApp messages when there are changes to your application status.',
+    Icon: MessageCircle
+  }
+}
+
+function formatTimestamp(timestamp?: string | null) {
+  if (!timestamp) {
+    return null
+  }
+
+  try {
+    return format(new Date(timestamp), 'PPP p')
+  } catch (error) {
+    console.error('Failed to format timestamp:', error)
+    return timestamp
+  }
+}
+
+function resolveChannelEntry(preferences: NotificationPreferencesResponse | null, channel: ChannelKey) {
+  const entry = preferences?.channels?.find(item => item.type === channel)
+  return entry ?? { type: channel, enabled: false, priority: channel === 'sms' ? 2 : 3 }
+}
+
+function isChannelOptedIn(preferences: NotificationPreferencesResponse | null, channel: ChannelKey) {
+  if (!preferences) {
+    return false
+  }
+
+  const entry = resolveChannelEntry(preferences, channel)
+  if (!entry.enabled) {
+    return false
+  }
+
+  const optInAt = channel === 'sms' ? preferences.sms_opt_in_at : preferences.whatsapp_opt_in_at
+  const optOutAt = channel === 'sms' ? preferences.sms_opt_out_at : preferences.whatsapp_opt_out_at
+
+  return Boolean(optInAt) && !optOutAt
+}
+
+export default function NotificationSettings() {
+  const [loading, setLoading] = useState(true)
+  const [preferences, setPreferences] = useState<NotificationPreferencesResponse | null>(null)
+  const [savingChannel, setSavingChannel] = useState<ChannelKey | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  const fetchPreferences = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+
+      const response = await notificationService.getPreferences()
+      setPreferences(response)
+    } catch (requestError) {
+      const message = requestError instanceof Error ? requestError.message : 'Failed to load notification preferences'
+      setError(message)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void fetchPreferences()
+  }, [fetchPreferences])
+
+  const hasPhoneNumber = Boolean(preferences?.phone)
+
+  const channelSummaries = useMemo(() => ({
+    sms: {
+      optInAt: formatTimestamp(preferences?.sms_opt_in_at),
+      optOutAt: formatTimestamp(preferences?.sms_opt_out_at),
+      optOutReason: preferences?.sms_opt_out_reason,
+      source: preferences?.sms_opt_in_source
+    },
+    whatsapp: {
+      optInAt: formatTimestamp(preferences?.whatsapp_opt_in_at),
+      optOutAt: formatTimestamp(preferences?.whatsapp_opt_out_at),
+      optOutReason: preferences?.whatsapp_opt_out_reason,
+      source: preferences?.whatsapp_opt_in_source
+    }
+  }), [preferences?.sms_opt_in_at, preferences?.sms_opt_in_source, preferences?.sms_opt_out_at, preferences?.sms_opt_out_reason, preferences?.whatsapp_opt_in_at, preferences?.whatsapp_opt_in_source, preferences?.whatsapp_opt_out_at, preferences?.whatsapp_opt_out_reason])
+
+  const handleConsentChange = async (channel: ChannelKey, enable: boolean) => {
+    if (!preferences) {
+      return
+    }
+
+    setSavingChannel(channel)
+    setError(null)
+    setSuccess(null)
+
+    try {
+      const action = enable ? 'opt_in' : 'opt_out'
+      const updatedPreferences = await notificationService.updateConsent({
+        channel,
+        action,
+        source: 'student_settings_page'
+      })
+
+      setPreferences(prev => ({
+        ...(prev ?? {}),
+        ...updatedPreferences,
+        phone: prev?.phone ?? updatedPreferences.phone ?? null
+      }))
+
+      setSuccess(enable ? `${CHANNEL_DETAILS[channel].title} consent enabled.` : `${CHANNEL_DETAILS[channel].title} consent revoked.`)
+    } catch (requestError) {
+      const message = requestError instanceof Error ? requestError.message : 'Failed to update consent preferences'
+      setError(message)
+    } finally {
+      setSavingChannel(null)
+    }
+  }
+
+  const renderChannelCard = (channel: ChannelKey) => {
+    const details = CHANNEL_DETAILS[channel]
+    const optedIn = isChannelOptedIn(preferences, channel)
+    const entry = resolveChannelEntry(preferences, channel)
+    const summary = channelSummaries[channel]
+    const disableGrant = !hasPhoneNumber && !optedIn
+    const buttonLabel = optedIn ? 'Revoke Consent' : 'Grant Consent'
+
+    return (
+      <motion.div
+        key={channel}
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: channel === 'sms' ? 0.1 : 0.2 }}
+        className="bg-white rounded-2xl shadow-lg border border-gray-100 p-6 space-y-4"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-start gap-3">
+            <div className="p-3 rounded-xl bg-blue-100 text-blue-600 shadow-inner">
+              <details.Icon className="h-6 w-6" />
+            </div>
+            <div>
+              <h2 className="text-lg font-bold text-gray-900">{details.title}</h2>
+              <p className="text-sm text-gray-600">{details.description}</p>
+            </div>
+          </div>
+          <span
+            className={`px-3 py-1 rounded-full text-xs font-semibold ${
+              optedIn ? 'bg-emerald-50 text-emerald-600 border border-emerald-200' : 'bg-gray-100 text-gray-600 border border-gray-200'
+            }`}
+          >
+            {optedIn ? 'Enabled' : 'Disabled'}
+          </span>
+        </div>
+
+        <div className="space-y-2 text-sm text-gray-700">
+          {optedIn && summary.optInAt && (
+            <p>
+              <span className="font-semibold">Opted in:</span> {summary.optInAt}
+              {summary.source && <span className="text-gray-500"> · via {summary.source}</span>}
+            </p>
+          )}
+
+          {!optedIn && summary.optOutAt && (
+            <p>
+              <span className="font-semibold">Consent revoked:</span> {summary.optOutAt}
+              {summary.optOutReason && <span className="text-gray-500"> · {summary.optOutReason}</span>}
+            </p>
+          )}
+
+          {!optedIn && !summary.optOutAt && (
+            <p className="text-gray-600">You are not currently receiving {details.title.toLowerCase()}.</p>
+          )}
+
+          {disableGrant && (
+            <div className="rounded-xl bg-yellow-50 border border-yellow-200 px-4 py-3 text-xs text-yellow-700">
+              <p className="font-medium">Add a valid phone number in your profile to enable this channel.</p>
+              <p>
+                <Link to="/settings" className="underline font-semibold text-yellow-800">
+                  Update contact information
+                </Link>
+              </p>
+            </div>
+          )}
+
+          <div className="flex flex-col gap-2 text-xs text-gray-500">
+            <span className="uppercase tracking-wide text-gray-400 font-semibold">Current contact</span>
+            <span className="text-sm text-gray-700">{preferences?.phone || 'No phone number on file'}</span>
+          </div>
+        </div>
+
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 pt-2 border-t border-gray-100">
+          <div className="text-xs text-gray-500">
+            Priority: <span className="font-medium text-gray-700">{entry.priority}</span>
+          </div>
+          <Button
+            type="button"
+            variant={optedIn ? 'outline' : 'primary'}
+            loading={savingChannel === channel}
+            disabled={savingChannel === channel || disableGrant}
+            onClick={() => handleConsentChange(channel, !optedIn)}
+          >
+            {savingChannel === channel ? 'Saving…' : buttonLabel}
+          </Button>
+        </div>
+      </motion.div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50">
+      <AuthenticatedNavigation />
+      <div className="container-mobile py-4 sm:py-6 lg:py-8 safe-area-bottom">
+        <div className="mb-6 sm:mb-8">
+          <Link
+            to="/settings"
+            className="inline-flex items-center text-primary hover:text-primary/80 mb-4 font-medium transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back to Profile Settings
+          </Link>
+
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="bg-gradient-to-r from-primary to-secondary rounded-2xl p-6 sm:p-8 text-white shadow-xl"
+          >
+            <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-2">Notification Preferences</h1>
+            <p className="text-lg sm:text-xl text-white/90">
+              Control how we contact you about important application updates.
+            </p>
+          </motion.div>
+        </div>
+
+        {error && (
+          <motion.div
+            initial={{ opacity: 0, y: -20 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="rounded-xl bg-red-50 border border-red-200 p-4 sm:p-6 mb-6 shadow-lg"
+          >
+            <div className="flex items-center space-x-3">
+              <div className="text-3xl">⚠️</div>
+              <div className="text-red-700 font-medium">{error}</div>
+            </div>
+          </motion.div>
+        )}
+
+        {success && (
+          <motion.div
+            initial={{ opacity: 0, y: -20 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="rounded-xl bg-emerald-50 border border-emerald-200 p-4 sm:p-6 mb-6 shadow-lg"
+          >
+            <div className="flex items-center space-x-3">
+              <div className="text-3xl">✅</div>
+              <div className="text-emerald-700 font-medium">{success}</div>
+            </div>
+          </motion.div>
+        )}
+
+        {loading ? (
+          <div className="flex justify-center items-center py-20">
+            <LoadingSpinner size="lg" />
+          </div>
+        ) : (
+          <div className="grid gap-6 lg:grid-cols-2">
+            {(['sms', 'whatsapp'] as ChannelKey[]).map(channel => renderChannelCard(channel))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/routes/config.tsx
+++ b/src/routes/config.tsx
@@ -11,6 +11,7 @@ const AuthCallbackPage = React.lazy(() => import('@/pages/auth/AuthCallbackPage'
 const ApplicationWizard = React.lazy(() => import('@/pages/student/ApplicationWizard'))
 const ApplicationStatus = React.lazy(() => import('@/pages/student/ApplicationStatus'))
 const StudentSettings = React.lazy(() => import('@/pages/student/Settings'))
+const StudentNotificationSettings = React.lazy(() => import('@/pages/student/NotificationSettings'))
 const AdminDashboard = React.lazy(() => import('@/pages/admin/Dashboard'))
 const AdminApplications = React.lazy(() => import('@/pages/admin/Applications'))
 const ApplicationsAdmin = React.lazy(() => import('@/pages/admin/ApplicationsAdmin'))
@@ -57,6 +58,7 @@ export const routes: RouteConfig[] = [
   { path: '/student/application-wizard', element: ApplicationWizard, guard: 'auth', lazy: true },
   { path: '/application/:id', element: ApplicationStatus, guard: 'auth', lazy: true },
   { path: '/settings', element: StudentSettings, guard: 'auth', lazy: true },
+  { path: '/student/notifications', element: StudentNotificationSettings, guard: 'auth', lazy: true },
   
   // Admin routes
   { path: '/admin', element: AdminDashboard, guard: 'admin', lazy: true },

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -1,7 +1,22 @@
 import { apiClient } from './client'
 
+type DispatchChannelPayload = {
+  userId: string
+  channel: 'sms' | 'whatsapp'
+  type: string
+  content: string
+  metadata?: Record<string, unknown>
+}
+
+type UpdateConsentPayload = {
+  channel: 'sms' | 'whatsapp'
+  action: 'opt_in' | 'opt_out'
+  source?: string
+  reason?: string
+}
+
 export const notificationService = {
-  send: (data: { userId: string; type: string; title: string; message: string; data?: any }) =>
+  send: (data: { userId: string; type: string; title: string; message: string; data?: Record<string, unknown> }) =>
     apiClient.request('/api/notifications?action=send', {
       method: 'POST',
       body: JSON.stringify(data)
@@ -10,5 +25,19 @@ export const notificationService = {
     apiClient.request('/api/notifications?action=application-submitted', {
       method: 'POST',
       body: JSON.stringify(data)
+    }),
+  dispatchChannel: (payload: DispatchChannelPayload) =>
+    apiClient.request('/api/notifications?action=dispatch-channel', {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    }),
+  getPreferences: () =>
+    apiClient.request('/api/notifications?action=preferences', {
+      method: 'GET'
+    }),
+  updateConsent: (payload: UpdateConsentPayload) =>
+    apiClient.request('/api/notifications?action=update-consent', {
+      method: 'POST',
+      body: JSON.stringify(payload)
     })
 }

--- a/supabase/migrations/20250315000000_notification_consent_audit.sql
+++ b/supabase/migrations/20250315000000_notification_consent_audit.sql
@@ -1,0 +1,39 @@
+BEGIN;
+  ALTER TABLE public.user_notification_preferences
+    ADD COLUMN IF NOT EXISTS sms_opt_in_at timestamptz,
+    ADD COLUMN IF NOT EXISTS sms_opt_in_source text,
+    ADD COLUMN IF NOT EXISTS sms_opt_in_actor uuid,
+    ADD COLUMN IF NOT EXISTS sms_opt_out_at timestamptz,
+    ADD COLUMN IF NOT EXISTS sms_opt_out_source text,
+    ADD COLUMN IF NOT EXISTS sms_opt_out_actor uuid,
+    ADD COLUMN IF NOT EXISTS sms_opt_out_reason text,
+    ADD COLUMN IF NOT EXISTS whatsapp_opt_in_at timestamptz,
+    ADD COLUMN IF NOT EXISTS whatsapp_opt_in_source text,
+    ADD COLUMN IF NOT EXISTS whatsapp_opt_in_actor uuid,
+    ADD COLUMN IF NOT EXISTS whatsapp_opt_out_at timestamptz,
+    ADD COLUMN IF NOT EXISTS whatsapp_opt_out_source text,
+    ADD COLUMN IF NOT EXISTS whatsapp_opt_out_actor uuid,
+    ADD COLUMN IF NOT EXISTS whatsapp_opt_out_reason text;
+
+  COMMENT ON COLUMN public.user_notification_preferences.sms_opt_in_at IS 'Timestamp recording when the user granted SMS delivery consent.';
+  COMMENT ON COLUMN public.user_notification_preferences.sms_opt_in_source IS 'Source describing how SMS consent was granted (e.g. student_settings_page).';
+  COMMENT ON COLUMN public.user_notification_preferences.sms_opt_in_actor IS 'Identifier of the actor who granted SMS consent (usually the user).';
+  COMMENT ON COLUMN public.user_notification_preferences.sms_opt_out_at IS 'Timestamp recording when SMS consent was revoked.';
+  COMMENT ON COLUMN public.user_notification_preferences.sms_opt_out_source IS 'Source describing how SMS consent was revoked.';
+  COMMENT ON COLUMN public.user_notification_preferences.sms_opt_out_actor IS 'Identifier of the actor who revoked SMS consent.';
+  COMMENT ON COLUMN public.user_notification_preferences.sms_opt_out_reason IS 'Optional reason supplied when SMS consent was revoked.';
+  COMMENT ON COLUMN public.user_notification_preferences.whatsapp_opt_in_at IS 'Timestamp recording when the user granted WhatsApp delivery consent.';
+  COMMENT ON COLUMN public.user_notification_preferences.whatsapp_opt_in_source IS 'Source describing how WhatsApp consent was granted.';
+  COMMENT ON COLUMN public.user_notification_preferences.whatsapp_opt_in_actor IS 'Identifier of the actor who granted WhatsApp consent.';
+  COMMENT ON COLUMN public.user_notification_preferences.whatsapp_opt_out_at IS 'Timestamp recording when WhatsApp consent was revoked.';
+  COMMENT ON COLUMN public.user_notification_preferences.whatsapp_opt_out_source IS 'Source describing how WhatsApp consent was revoked.';
+  COMMENT ON COLUMN public.user_notification_preferences.whatsapp_opt_out_actor IS 'Identifier of the actor who revoked WhatsApp consent.';
+  COMMENT ON COLUMN public.user_notification_preferences.whatsapp_opt_out_reason IS 'Optional reason supplied when WhatsApp consent was revoked.';
+
+  ALTER TABLE public.notification_logs
+    ADD COLUMN IF NOT EXISTS channel_statuses jsonb NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN IF NOT EXISTS provider_message_ids jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+  COMMENT ON COLUMN public.notification_logs.channel_statuses IS 'Per-channel delivery states captured after dispatch (e.g. sent, blocked, failed).';
+  COMMENT ON COLUMN public.notification_logs.provider_message_ids IS 'Provider message identifiers keyed by channel for traceability.';
+COMMIT;

--- a/tests/unit/multiChannelNotifications.test.ts
+++ b/tests/unit/multiChannelNotifications.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+
+const insertSpy = vi.fn()
+
+const { supabaseMock, fromMock } = vi.hoisted(() => {
+  const from = vi.fn()
+  return {
+    supabaseMock: { from },
+    fromMock: from
+  }
+})
+
+const { notificationServiceMock, dispatchChannelMock } = vi.hoisted(() => {
+  const dispatch = vi.fn()
+  return {
+    notificationServiceMock: { dispatchChannel: dispatch },
+    dispatchChannelMock: dispatch
+  }
+})
+
+vi.mock('@/lib/supabase', () => ({ supabase: supabaseMock }))
+
+vi.mock('@/services/notifications', () => ({ notificationService: notificationServiceMock }))
+
+import { multiChannelNotifications } from '@/lib/multiChannelNotifications'
+
+function mockSupabaseResponses(preferences: Record<string, unknown>) {
+  fromMock.mockImplementation((table: string) => {
+    if (table === 'user_notification_preferences') {
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: () => Promise.resolve({ data: preferences })
+          })
+        })
+      }
+    }
+
+    if (table === 'notification_logs') {
+      return {
+        insert: (payload: Record<string, unknown>) => {
+          insertSpy(payload)
+          return Promise.resolve({ error: null })
+        }
+      }
+    }
+
+    throw new Error(`Unexpected table requested: ${table}`)
+  })
+}
+
+const basePreferences = {
+  channels: [
+    { type: 'email', enabled: true, priority: 1 },
+    { type: 'sms', enabled: true, priority: 2 },
+    { type: 'whatsapp', enabled: true, priority: 3 },
+    { type: 'in_app', enabled: true, priority: 4 }
+  ],
+  frequency: 'immediate',
+  optimalTiming: true,
+  sms_opt_in_at: null,
+  sms_opt_in_source: null,
+  sms_opt_in_actor: null,
+  sms_opt_out_at: null,
+  sms_opt_out_source: null,
+  sms_opt_out_actor: null,
+  sms_opt_out_reason: null,
+  whatsapp_opt_in_at: null,
+  whatsapp_opt_in_source: null,
+  whatsapp_opt_in_actor: null,
+  whatsapp_opt_out_at: null,
+  whatsapp_opt_out_source: null,
+  whatsapp_opt_out_actor: null,
+  whatsapp_opt_out_reason: null
+}
+
+beforeEach(() => {
+  fromMock.mockReset()
+  insertSpy.mockReset()
+  dispatchChannelMock.mockReset()
+})
+
+describe('MultiChannelNotificationService consent gating', () => {
+  it('blocks SMS dispatch when the channel lacks explicit opt-in consent', async () => {
+    mockSupabaseResponses({
+      ...basePreferences,
+      sms_opt_in_at: null,
+      sms_opt_out_at: null,
+      channels: basePreferences.channels
+    })
+
+    const result = await multiChannelNotifications.sendNotification(
+      'user-123',
+      'application_approved',
+      { full_name: 'Test Student', program: 'Nursing', institution: 'MIHAS' },
+      ['sms']
+    )
+
+    expect(result).toBe(false)
+    expect(dispatchChannelMock).not.toHaveBeenCalled()
+
+    expect(insertSpy).toHaveBeenCalledTimes(1)
+    const payload = insertSpy.mock.calls[0][0]
+    expect(payload.channel_statuses).toEqual({ sms: 'blocked' })
+    expect(payload.success_count).toBe(0)
+    expect(payload.total_count).toBe(1)
+  })
+
+  it('dispatches to all opted-in channels and records provider metadata', async () => {
+    mockSupabaseResponses({
+      ...basePreferences,
+      sms_opt_in_at: '2025-03-01T10:00:00Z',
+      whatsapp_opt_in_at: '2025-03-01T10:05:00Z',
+      sms_opt_out_at: null,
+      whatsapp_opt_out_at: null
+    })
+
+    dispatchChannelMock
+      .mockResolvedValueOnce({ success: true, status: 'queued', messageId: 'SM123' })
+      .mockResolvedValueOnce({ success: true, status: 'sent', messageId: 'WA456' })
+
+    const result = await multiChannelNotifications.sendNotification(
+      'user-123',
+      'application_approved',
+      { full_name: 'Test Student', program: 'Nursing', institution: 'MIHAS' },
+      ['sms', 'whatsapp']
+    )
+
+    expect(result).toBe(true)
+    expect(dispatchChannelMock).toHaveBeenCalledTimes(2)
+    expect(dispatchChannelMock).toHaveBeenNthCalledWith(1, {
+      channel: 'sms',
+      content: expect.any(String),
+      type: 'application_approved',
+      userId: 'user-123'
+    })
+    expect(dispatchChannelMock).toHaveBeenNthCalledWith(2, {
+      channel: 'whatsapp',
+      content: expect.any(String),
+      type: 'application_approved',
+      userId: 'user-123'
+    })
+
+    const payload = insertSpy.mock.calls[0][0]
+    expect(payload.success_count).toBe(2)
+    expect(payload.channel_statuses).toEqual({ sms: 'queued', whatsapp: 'sent' })
+    expect(payload.provider_message_ids).toEqual({ sms: 'SM123', whatsapp: 'WA456' })
+  })
+})


### PR DESCRIPTION
## Summary
- integrate Twilio-backed SMS and WhatsApp dispatch into the notifications API with consent management endpoints
- update the multi-channel notification service to honor opt-in status, call the new API, and persist provider metadata
- add a student notification settings page, navigation entry, consent services, database migration, and regression tests for consent gating

## Testing
- npx vitest run tests/unit/multiChannelNotifications.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cd2ba201e88332a8f6fa81bb9fd859