### PR TITLE
Load programs dynamically in application wizard

### DIFF
--- a/src/pages/student/applicationWizard/__tests__/ApplicationWizard.test.tsx
+++ b/src/pages/student/applicationWizard/__tests__/ApplicationWizard.test.tsx
@@ -81,6 +81,7 @@ const createControllerReturn = (overrides: Partial<ReturnType<typeof mockUseWiza
     selectedGrades: baseGrades,
     eligibilityCheck: null,
     recommendedSubjects: [],
+    programs: [],
     subjects: [],
     hasAutoPopulatedData: false,
     completionPercentage: 0,

--- a/src/pages/student/applicationWizard/index.tsx
+++ b/src/pages/student/applicationWizard/index.tsx
@@ -34,6 +34,7 @@ const ApplicationWizard = () => {
     selectedGrades,
     eligibilityCheck,
     recommendedSubjects,
+    programs,
     subjects,
     hasAutoPopulatedData,
     completionPercentage,
@@ -201,6 +202,7 @@ const ApplicationWizard = () => {
                 hasAutoPopulatedData={hasAutoPopulatedData}
                 completionPercentage={completionPercentage}
                 selectedProgram={selectedProgram}
+                programs={programs}
                 title={currentStepConfig.title}
               />
             )}

--- a/src/pages/student/applicationWizard/types.ts
+++ b/src/pages/student/applicationWizard/types.ts
@@ -1,37 +1,62 @@
 import { z } from 'zod'
 
-export const wizardSchema = z.object({
-  full_name: z.string().min(2, 'Full name is required'),
-  nrc_number: z.string().optional(),
-  passport_number: z.string().optional(),
-  date_of_birth: z.string().min(1, 'Date of birth is required'),
-  sex: z.enum(['Male', 'Female'], { required_error: 'Please select sex' }),
-  phone: z.string().min(10, 'Valid phone number is required'),
-  email: z.string().email('Valid email is required'),
-  residence_town: z.string().min(2, 'Residence town is required'),
-  next_of_kin_name: z.string().optional(),
-  next_of_kin_phone: z.string().optional(),
-  program: z.enum(['Clinical Medicine', 'Environmental Health', 'Registered Nursing'], {
-    required_error: 'Please select a program'
-  }),
-  intake: z.string().min(1, 'Please select an intake'),
-  payment_method: z
-    .enum(['MTN Money', 'Airtel Money', 'Zamtel Money', 'Ewallet', 'Bank To Cell'])
-    .default('MTN Money'),
-  payer_name: z.string().optional(),
-  payer_phone: z.string().optional(),
-  amount: z.number().min(153, 'Minimum amount is K153').optional(),
-  paid_at: z.string().optional(),
-  momo_ref: z.string().optional()
-}).refine(
-  data => Boolean(data.nrc_number || data.passport_number),
-  {
-    message: 'Either NRC or Passport number is required',
-    path: ['nrc_number']
-  }
-)
+import type { Institution, Program } from '@/lib/supabase'
 
-export type WizardFormData = z.infer<typeof wizardSchema>
+type InstitutionSummary = Pick<Institution, 'id' | 'name' | 'full_name'>
+
+export type WizardProgram = Program & {
+  institutions?: InstitutionSummary | null
+}
+
+const createProgramValidator = (validProgramNames: string[]) =>
+  z
+    .string({ required_error: 'Please select a program' })
+    .min(1, 'Please select a program')
+    .refine(
+      value =>
+        value.trim().length > 0 && (validProgramNames.length === 0 || validProgramNames.includes(value)),
+      {
+        message: 'Please select a valid program',
+      }
+    )
+
+const createSchema = (validProgramNames: string[]) =>
+  z
+    .object({
+      full_name: z.string().min(2, 'Full name is required'),
+      nrc_number: z.string().optional(),
+      passport_number: z.string().optional(),
+      date_of_birth: z.string().min(1, 'Date of birth is required'),
+      sex: z.enum(['Male', 'Female'], { required_error: 'Please select sex' }),
+      phone: z.string().min(10, 'Valid phone number is required'),
+      email: z.string().email('Valid email is required'),
+      residence_town: z.string().min(2, 'Residence town is required'),
+      next_of_kin_name: z.string().optional(),
+      next_of_kin_phone: z.string().optional(),
+      program: createProgramValidator(validProgramNames),
+      intake: z.string().min(1, 'Please select an intake'),
+      payment_method: z
+        .enum(['MTN Money', 'Airtel Money', 'Zamtel Money', 'Ewallet', 'Bank To Cell'])
+        .default('MTN Money'),
+      payer_name: z.string().optional(),
+      payer_phone: z.string().optional(),
+      amount: z.number().min(153, 'Minimum amount is K153').optional(),
+      paid_at: z.string().optional(),
+      momo_ref: z.string().optional(),
+    })
+    .refine(
+      data => Boolean(data.nrc_number || data.passport_number),
+      {
+        message: 'Either NRC or Passport number is required',
+        path: ['nrc_number'],
+      }
+    )
+
+export const createWizardSchema = createSchema
+
+export const wizardSchema = createWizardSchema([])
+
+export type WizardFormData = z.infer<ReturnType<typeof createWizardSchema>>
 
 export interface Grade12Subject {
   id: string


### PR DESCRIPTION
## Summary
- fetch the latest programs in the wizard controller, store them in state, and pass them into the step props
- populate the basic KYC program selector from the fetched catalog entries and show each option’s institution label
- update the wizard schema so program validation accepts dynamically supplied names instead of a fixed enum

## Testing
- npm run lint *(fails: existing warnings/errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd42813db483328cb5b364b77839a8