### PR TITLE
Use catalog intakes in student application wizard

### DIFF
--- a/src/pages/student/applicationWizard/index.tsx
+++ b/src/pages/student/applicationWizard/index.tsx
@@ -35,6 +35,7 @@ const ApplicationWizard = () => {
     eligibilityCheck,
     recommendedSubjects,
     programs,
+    intakes,
     subjects,
     hasAutoPopulatedData,
     completionPercentage,
@@ -203,6 +204,7 @@ const ApplicationWizard = () => {
                 completionPercentage={completionPercentage}
                 selectedProgram={selectedProgram}
                 programs={programs}
+                intakes={intakes}
                 title={currentStepConfig.title}
               />
             )}

--- a/src/pages/student/applicationWizard/steps/BasicKycStep.tsx
+++ b/src/pages/student/applicationWizard/steps/BasicKycStep.tsx
@@ -7,7 +7,7 @@ import type { UseFormReturn } from 'react-hook-form'
 import { Input } from '@/components/ui/Input'
 import { ProfileCompletionBadge } from '@/components/ui/ProfileAutoPopulationIndicator'
 
-import type { WizardFormData, WizardProgram } from '../types'
+import type { WizardFormData, WizardProgram, WizardIntake } from '../types'
 
 interface BasicKycStepProps {
   form: UseFormReturn<WizardFormData>
@@ -15,6 +15,7 @@ interface BasicKycStepProps {
   completionPercentage: number
   selectedProgram?: WizardFormData['program']
   programs: WizardProgram[]
+  intakes: WizardIntake[]
   title: string
 }
 
@@ -24,6 +25,7 @@ const BasicKycStep = ({
   completionPercentage,
   selectedProgram,
   programs,
+  intakes,
   title
 }: BasicKycStepProps) => {
   const {
@@ -40,6 +42,19 @@ const BasicKycStep = ({
     if (!selectedProgramDetails?.institutions) return undefined
     return selectedProgramDetails.institutions.full_name || selectedProgramDetails.institutions.name || undefined
   }, [selectedProgramDetails])
+
+  const formatDeadline = (date: string | undefined) => {
+    if (!date) return ''
+    try {
+      return new Date(date).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric'
+      })
+    } catch {
+      return ''
+    }
+  }
 
   return (
     <motion.div
@@ -207,12 +222,31 @@ const BasicKycStep = ({
           <select
             {...register('intake')}
             id="intake"
-            className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            disabled={intakes.length === 0}
+            className={`w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
+              intakes.length === 0 ? 'bg-gray-100 text-gray-500 cursor-not-allowed border-gray-200' : 'bg-white border-gray-300'
+            }`}
           >
             <option value="">Select intake</option>
-            <option value="January 2026">January 2026</option>
-            <option value="July 2026">July 2026</option>
+            {intakes.length === 0 && (
+              <option value="" disabled>
+                Intakes currently unavailable
+              </option>
+            )}
+            {intakes.map(intake => {
+              const label = intake.displayName
+              const deadline = formatDeadline(intake.application_deadline)
+              const optionLabel = deadline ? `${label} — Apply by ${deadline}` : label
+              return (
+                <option key={intake.id} value={label}>
+                  {optionLabel}
+                </option>
+              )
+            })}
           </select>
+          {intakes.length === 0 && (
+            <p className="mt-1 text-sm text-gray-500">Intakes will appear here once enrollment periods are announced.</p>
+          )}
           {errors.intake && <p className="mt-1 text-sm text-red-600">{errors.intake.message}</p>}
         </div>
       </div>

--- a/src/pages/student/applicationWizard/types.ts
+++ b/src/pages/student/applicationWizard/types.ts
@@ -1,11 +1,15 @@
 import { z } from 'zod'
 
-import type { Institution, Program } from '@/lib/supabase'
+import type { Institution, Program, Intake } from '@/lib/supabase'
 
 type InstitutionSummary = Pick<Institution, 'id' | 'name' | 'full_name'>
 
 export type WizardProgram = Program & {
   institutions?: InstitutionSummary | null
+}
+
+export type WizardIntake = Intake & {
+  displayName: string
 }
 
 const createProgramValidator = (validProgramNames: string[]) =>
@@ -20,7 +24,19 @@ const createProgramValidator = (validProgramNames: string[]) =>
       }
     )
 
-const createSchema = (validProgramNames: string[]) =>
+const createIntakeValidator = (validIntakeOptions: string[]) =>
+  z
+    .string({ required_error: 'Please select an intake' })
+    .min(1, 'Please select an intake')
+    .refine(
+      value =>
+        value.trim().length > 0 && (validIntakeOptions.length === 0 || validIntakeOptions.includes(value)),
+      {
+        message: 'Please select a valid intake',
+      }
+    )
+
+const createSchema = (validProgramNames: string[], validIntakeOptions: string[]) =>
   z
     .object({
       full_name: z.string().min(2, 'Full name is required'),
@@ -34,7 +50,7 @@ const createSchema = (validProgramNames: string[]) =>
       next_of_kin_name: z.string().optional(),
       next_of_kin_phone: z.string().optional(),
       program: createProgramValidator(validProgramNames),
-      intake: z.string().min(1, 'Please select an intake'),
+      intake: createIntakeValidator(validIntakeOptions),
       payment_method: z
         .enum(['MTN Money', 'Airtel Money', 'Zamtel Money', 'Ewallet', 'Bank To Cell'])
         .default('MTN Money'),
@@ -54,7 +70,7 @@ const createSchema = (validProgramNames: string[]) =>
 
 export const createWizardSchema = createSchema
 
-export const wizardSchema = createWizardSchema([])
+export const wizardSchema = createWizardSchema([], [])
 
 export type WizardFormData = z.infer<ReturnType<typeof createWizardSchema>>
 


### PR DESCRIPTION
## Summary
- load admission intakes from the catalog into the student application wizard controller
- render the Basic KYC intake selector from the fetched intake collection with deadline context and disabled fallback
- validate intake selections against admin-managed records so saved applications use catalog-managed values

## Testing
- `npm run type-check`
- `npm run lint` *(fails: existing repository lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4449d19c833297a09fd19804d242