### PR TITLE
Add user permissions management for admin users

### DIFF
--- a/api/admin/users/[id].js
+++ b/api/admin/users/[id].js
@@ -26,6 +26,35 @@ module.exports = async function handler(req, res) {
     const action = parseAction(req.query?.action)
 
     if (req.method === 'GET') {
+      if (action === 'permissions') {
+        const { data: permissionsRecord, error: permissionsError } = await supabaseAdminClient
+          .from('user_permissions')
+          .select('permissions')
+          .eq('user_id', userId)
+          .maybeSingle()
+
+        if (permissionsError && permissionsError.code !== 'PGRST116') {
+          throw permissionsError
+        }
+
+        const permissions = Array.isArray(permissionsRecord?.permissions)
+          ? permissionsRecord.permissions
+          : []
+
+        await logAuditEvent({
+          req,
+          action: 'admin.users.permissions.view',
+          actorId: user.id,
+          actorEmail: user.email || null,
+          actorRoles: roles,
+          targetTable: 'user_permissions',
+          targetId: userId,
+          metadata: { permissionsCount: permissions.length }
+        })
+
+        return res.status(200).json({ data: permissions })
+      }
+
       if (action === 'role') {
         const activeRole = await fetchActiveRole(userId)
 
@@ -61,6 +90,56 @@ module.exports = async function handler(req, res) {
     }
 
     if (req.method === 'PUT') {
+      if (action === 'permissions') {
+        const payload = parseRequestBody(req.body)
+        const { permissions } = payload || {}
+
+        if (!Array.isArray(permissions)) {
+          return res.status(400).json({ error: 'Permissions must be provided as an array' })
+        }
+
+        const sanitizedPermissions = Array.from(
+          new Set(
+            permissions
+              .filter(permission => typeof permission === 'string')
+              .map(permission => permission.trim())
+              .filter(Boolean)
+          )
+        )
+
+        const nowIso = new Date().toISOString()
+
+        const { data: upsertedRecord, error: upsertError } = await supabaseAdminClient
+          .from('user_permissions')
+          .upsert(
+            {
+              user_id: userId,
+              permissions: sanitizedPermissions,
+              updated_at: nowIso
+            },
+            { onConflict: 'user_id' }
+          )
+          .select('permissions')
+          .single()
+
+        if (upsertError) {
+          throw upsertError
+        }
+
+        await logAuditEvent({
+          req,
+          action: 'admin.users.permissions.update',
+          actorId: user.id,
+          actorEmail: user.email || null,
+          actorRoles: roles,
+          targetTable: 'user_permissions',
+          targetId: userId,
+          metadata: { permissionsCount: sanitizedPermissions.length }
+        })
+
+        return res.status(200).json({ data: upsertedRecord?.permissions ?? sanitizedPermissions })
+      }
+
       const payload = parseRequestBody(req.body)
       const allowedFields = ['full_name', 'email', 'phone', 'role']
       const updates = {}

--- a/src/hooks/useApiServices.ts
+++ b/src/hooks/useApiServices.ts
@@ -113,11 +113,36 @@ export const useUpdateUser = () => {
 
 export const useDeleteUser = () => {
   const queryClient = useQueryClient()
-  
+
   return useMutation({
     mutationFn: userService.remove,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['users'] })
+    }
+  })
+}
+
+export const useUserPermissions = (userId?: string) => {
+  return useQuery({
+    queryKey: ['user-permissions', userId],
+    queryFn: () => {
+      if (!userId) {
+        return { data: [] }
+      }
+      return userService.getPermissions(userId)
+    },
+    enabled: Boolean(userId)
+  })
+}
+
+export const useUpdateUserPermissions = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ id, permissions }: { id: string; permissions: string[] }) =>
+      userService.updatePermissions(id, permissions),
+    onSuccess: (_, { id }) => {
+      queryClient.invalidateQueries({ queryKey: ['user-permissions', id] })
     }
   })
 }

--- a/src/services/admin/users.ts
+++ b/src/services/admin/users.ts
@@ -4,6 +4,7 @@ export const userService = {
   list: () => apiClient.request('/api/admin/users'),
   getById: (id: string) => apiClient.request(`/api/admin/users/${id}`),
   getRole: (id: string) => apiClient.request(`/api/admin/users/${id}?action=role`),
+  getPermissions: (id: string) => apiClient.request(`/api/admin/users/${id}?action=permissions`),
   create: (data: { email: string; password: string; full_name: string; phone?: string; role: string }) =>
     apiClient.request('/api/admin/users', {
       method: 'POST',
@@ -13,6 +14,11 @@ export const userService = {
     apiClient.request(`/api/admin/users/${id}`, {
       method: 'PUT',
       body: JSON.stringify(data)
+    }),
+  updatePermissions: (id: string, permissions: string[]) =>
+    apiClient.request(`/api/admin/users/${id}?action=permissions`, {
+      method: 'PUT',
+      body: JSON.stringify({ permissions })
     }),
   remove: (id: string) =>
     apiClient.request(`/api/admin/users/${id}`, {

--- a/supabase/migrations/20250415000000_user_permissions.sql
+++ b/supabase/migrations/20250415000000_user_permissions.sql
@@ -1,0 +1,35 @@
+BEGIN;
+  CREATE TABLE IF NOT EXISTS public.user_permissions (
+    user_id uuid PRIMARY KEY,
+    permissions text[] NOT NULL DEFAULT '{}'::text[],
+    created_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now()),
+    updated_at timestamptz NOT NULL DEFAULT timezone('utc'::text, now())
+  );
+
+  ALTER TABLE public.user_permissions
+    ADD CONSTRAINT user_permissions_user_fk
+    FOREIGN KEY (user_id)
+    REFERENCES public.user_profiles (user_id)
+    ON DELETE CASCADE;
+
+  CREATE INDEX IF NOT EXISTS user_permissions_user_idx ON public.user_permissions (user_id);
+
+  COMMENT ON TABLE public.user_permissions IS 'Stores fine-grained permission overrides for admin-managed users.';
+
+  CREATE OR REPLACE FUNCTION public.set_user_permissions_updated_at()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  AS $$
+  BEGIN
+    NEW.updated_at = timezone('utc'::text, now());
+    RETURN NEW;
+  END;
+  $$;
+
+  DROP TRIGGER IF EXISTS set_user_permissions_updated_at ON public.user_permissions;
+
+  CREATE TRIGGER set_user_permissions_updated_at
+  BEFORE UPDATE ON public.user_permissions
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_user_permissions_updated_at();
+COMMIT;


### PR DESCRIPTION
## Summary
- create a `user_permissions` table to store custom permission sets for each user
- extend the admin user API to read and update stored permissions with audit logging
- add client services, hooks, and UI updates so permissions are persisted through the new API

## Testing
- npm run lint *(fails: existing repository lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cd47f644688332a103f76b98c9fe24