### PR TITLE
refactor: add domain types for user and application flows

### DIFF
--- a/src/components/admin/ApplicationsTable.tsx
+++ b/src/components/admin/ApplicationsTable.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
-import { useApplications } from '@/hooks/useApiServices'
+
 import { Button } from '@/components/ui/Button'
+import { useApplications } from '@/hooks/useApiServices'
+import { Application } from '@/lib/supabase'
 
 export function ApplicationsTable() {
   const { data: applications, isLoading, error } = useApplications()
@@ -31,7 +33,7 @@ export function ApplicationsTable() {
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-200">
-          {applications?.map((app: any) => (
+          {applications?.map((app: Application) => (
             <tr key={app.id}>
               <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
                 {app.application_number}

--- a/src/hooks/useApiServices.ts
+++ b/src/hooks/useApiServices.ts
@@ -1,9 +1,13 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useAuth } from '@/contexts/AuthContext'
+import { Application } from '@/lib/supabase'
 import { applicationService } from '@/services/applications'
 import { documentService } from '@/services/documents'
 import { analyticsService } from '@/services/analytics'
 import { userService } from '@/services/admin/users'
+
+type UserUpdateInput = Parameters<typeof userService.update>[1]
+type RegistrationMetadata = Record<string, unknown>
 
 // Auth hooks
 export const useLogin = () => {
@@ -19,21 +23,21 @@ export const useRegister = () => {
   const { signUp } = useAuth()
 
   return useMutation({
-    mutationFn: ({ email, password, userData }: { email: string; password: string; userData: any }) =>
+    mutationFn: ({ email, password, userData }: { email: string; password: string; userData: RegistrationMetadata }) =>
       signUp(email, password, userData)
   })
 }
 
 // Application hooks
 export const useApplications = () => {
-  return useQuery({
+  return useQuery<Application[] | null>({
     queryKey: ['applications'],
     queryFn: applicationService.getAll
   })
 }
 
 export const useApplication = (id: string) => {
-  return useQuery({
+  return useQuery<Application | null>({
     queryKey: ['applications', id],
     queryFn: () => applicationService.getById(id),
     enabled: !!id
@@ -42,7 +46,7 @@ export const useApplication = (id: string) => {
 
 export const useCreateApplication = () => {
   const queryClient = useQueryClient()
-  
+
   return useMutation({
     mutationFn: applicationService.create,
     onSuccess: () => {
@@ -53,9 +57,9 @@ export const useCreateApplication = () => {
 
 export const useUpdateApplication = () => {
   const queryClient = useQueryClient()
-  
+
   return useMutation({
-    mutationFn: ({ id, data }: { id: string; data: any }) => 
+    mutationFn: ({ id, data }: { id: string; data: Partial<Application> }) =>
       applicationService.update(id, data),
     onSuccess: (_, { id }) => {
       queryClient.invalidateQueries({ queryKey: ['applications', id] })
@@ -103,7 +107,7 @@ export const useUpdateUser = () => {
   const queryClient = useQueryClient()
   
   return useMutation({
-    mutationFn: ({ id, data }: { id: string; data: any }) => 
+    mutationFn: ({ id, data }: { id: string; data: UserUpdateInput }) =>
       userService.update(id, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['users'] })

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { UseFormGetValues, UseFormWatch } from 'react-hook-form'
 import { supabase } from '@/lib/supabase'
 import { ApplicationFormData, UploadedFile } from '@/forms/applicationSchema'
+import { OfflineApplicationDraftData } from '@/types/offline'
 
 interface AutoSaveOptions {
   userId: string
@@ -55,7 +56,7 @@ export function useAutoSave({
       window.removeEventListener('online', handleOnline)
       window.removeEventListener('offline', handleOffline)
     }
-  }, [pendingChanges])
+  }, [pendingChanges, saveDraft])
 
   // Load existing draft
   const loadDraft = useCallback(async (): Promise<DraftData | null> => {
@@ -92,7 +93,7 @@ export function useAutoSave({
     
     try {
       const formData = getValues()
-      const draftData = {
+      const draftData: OfflineApplicationDraftData = {
         form_data: formData,
         uploaded_files: uploadedFiles,
         current_step: currentStep,
@@ -136,9 +137,10 @@ export function useAutoSave({
 
       // Clear offline data if exists
       localStorage.removeItem('applicationDraftOffline')
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error saving draft:', error)
-      onSaveError?.(error.message)
+      const message = error instanceof Error ? error.message : 'Failed to save draft'
+      onSaveError?.(message)
     } finally {
       setIsSaving(false)
     }

--- a/src/services/applications.ts
+++ b/src/services/applications.ts
@@ -1,45 +1,55 @@
-import { apiClient, buildQueryString } from './client'
+import { Application } from '@/lib/supabase'
+
+import { apiClient, buildQueryString, QueryParams } from './client'
 
 type ApplicationIncludeOptions = {
   include?: string[]
 }
 
+type ApplicationPayload = Partial<Application>
+
 export const applicationService = {
-  list: (params?: Record<string, any>) =>
-    apiClient.request(`/api/applications${buildQueryString(params)}`),
+  list: (params?: QueryParams) =>
+    apiClient.request<Application[]>(`/api/applications${buildQueryString(params ?? {})}`),
 
   // Alias for backward compatibility
-  getAll: (params?: Record<string, any>) =>
-    apiClient.request(`/api/applications${buildQueryString(params)}`),
+  getAll: (params?: QueryParams) =>
+    apiClient.request<Application[]>(`/api/applications${buildQueryString(params ?? {})}`),
 
   getById: (id: string, options?: ApplicationIncludeOptions) =>
-    apiClient.request(`/api/applications/${id}${buildQueryString({ include: options?.include })}`),
+    apiClient.request<Application>(
+      `/api/applications/${id}${buildQueryString({ include: options?.include ?? [] })}`
+    ),
 
-  create: (data: any) =>
-    apiClient.request('/api/applications', {
+  create: (data: ApplicationPayload) =>
+    apiClient.request<Application>('/api/applications', {
       method: 'POST',
       body: JSON.stringify(data)
     }),
 
-  update: (id: string, data: any) =>
-    apiClient.request(`/api/applications/${id}`, {
+  update: (id: string, data: ApplicationPayload) =>
+    apiClient.request<Application>(`/api/applications/${id}`, {
       method: 'PUT',
       body: JSON.stringify(data)
     }),
 
   delete: (id: string) =>
-    apiClient.request(`/api/applications/${id}`, {
+    apiClient.request<void>(`/api/applications/${id}`, {
       method: 'DELETE'
     }),
 
-  updateStatus: (id: string, status: string, notes?: string) =>
-    apiClient.request(`/api/applications/${id}`, {
+  updateStatus: (id: string, status: Application['status'], notes?: string) =>
+    apiClient.request<Application>(`/api/applications/${id}`, {
       method: 'PATCH',
       body: JSON.stringify({ action: 'update_status', status, notes })
     }),
 
-  updatePaymentStatus: (id: string, paymentStatus: string, verificationNotes?: string) =>
-    apiClient.request(`/api/applications/${id}`, {
+  updatePaymentStatus: (
+    id: string,
+    paymentStatus: Application['payment_status'],
+    verificationNotes?: string
+  ) =>
+    apiClient.request<Application>(`/api/applications/${id}`, {
       method: 'PATCH',
       body: JSON.stringify({
         action: 'update_payment_status',
@@ -52,31 +62,31 @@ export const applicationService = {
     id: string,
     payload: { documentId?: string; documentType?: string; status: string; notes?: string }
   ) =>
-    apiClient.request(`/api/applications/${id}`, {
+    apiClient.request<Application>(`/api/applications/${id}`, {
       method: 'PATCH',
       body: JSON.stringify({ action: 'verify_document', ...payload })
     }),
 
   syncGrades: (id: string, grades: Array<{ subject_id: string; grade: number }>) =>
-    apiClient.request(`/api/applications/${id}`, {
+    apiClient.request<Application>(`/api/applications/${id}`, {
       method: 'PATCH',
       body: JSON.stringify({ action: 'sync_grades', grades })
     }),
 
   sendNotification: (id: string, notification: { title: string; message: string }) =>
-    apiClient.request(`/api/applications/${id}`, {
+    apiClient.request<Application>(`/api/applications/${id}`, {
       method: 'PATCH',
       body: JSON.stringify({ action: 'send_notification', ...notification })
     }),
 
   generateAcceptanceLetter: (id: string) =>
-    apiClient.request(`/api/applications/${id}`, {
+    apiClient.request<Application>(`/api/applications/${id}`, {
       method: 'PATCH',
       body: JSON.stringify({ action: 'generate_acceptance_letter' })
     }),
 
   generateFinanceReceipt: (id: string) =>
-    apiClient.request(`/api/applications/${id}`, {
+    apiClient.request<Application>(`/api/applications/${id}`, {
       method: 'PATCH',
       body: JSON.stringify({ action: 'generate_finance_receipt' })
     })

--- a/src/types/eligibility.ts
+++ b/src/types/eligibility.ts
@@ -1,0 +1,30 @@
+import { EligibilityAssessment, MissingRequirement } from '@/lib/eligibilityEngine'
+
+export interface SupabaseEligibilityAssessmentRow extends EligibilityAssessment {
+  id: string
+  created_at: string
+  updated_at?: string | null
+  detailed_breakdown: string | EligibilityAssessment['detailed_breakdown']
+  missing_requirements: string | MissingRequirement[]
+  recommendations: string | string[]
+}
+
+export interface EligibilityAssessmentWithProgram extends SupabaseEligibilityAssessmentRow {
+  programs?: {
+    name: string | null
+    code?: string | null
+  } | null
+}
+
+export interface DashboardEligibilityAssessment {
+  id: string
+  application_id: string
+  program_id: string
+  overall_score: number
+  eligibility_status: EligibilityAssessment['eligibility_status']
+  missing_requirements: MissingRequirement[]
+  programs?: {
+    name: string | null
+    code?: string | null
+  } | null
+}

--- a/src/types/offline.ts
+++ b/src/types/offline.ts
@@ -1,0 +1,49 @@
+import { ApplicationFormData, UploadedFile } from '@/forms/applicationSchema'
+import { Application } from '@/lib/supabase'
+
+export type OfflineRecordType = 'application_draft' | 'document_upload' | 'form_submission'
+
+export interface OfflineApplicationDraftData {
+  form_data: Partial<ApplicationFormData>
+  uploaded_files: UploadedFile[]
+  current_step: number
+  version: number
+}
+
+export interface OfflineFormSubmissionData extends Partial<Application> {
+  application_fee?: number
+  payment_method?: string
+  payer_name?: string
+  payer_phone?: string
+  amount?: number
+  paid_at?: string
+  momo_ref?: string
+  pop_url?: string
+}
+
+export interface OfflineDocumentUploadData {
+  application_id: string
+  files: UploadedFile[]
+  metadata?: Record<string, string>
+}
+
+export type OfflineDataPayloadMap = {
+  application_draft: OfflineApplicationDraftData
+  document_upload: OfflineDocumentUploadData
+  form_submission: OfflineFormSubmissionData
+}
+
+export type OfflineQueueItem<TType extends OfflineRecordType = OfflineRecordType> = {
+  id: string
+  type: TType
+  data: OfflineDataPayloadMap[TType]
+  timestamp: number
+  userId: string
+}
+
+export type NewOfflineQueueItem<TType extends OfflineRecordType = OfflineRecordType> = Omit<
+  OfflineQueueItem<TType>,
+  'id' | 'timestamp'
+>
+
+export type OfflineQueuePayload = OfflineQueueItem['data']

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -1,0 +1,6 @@
+import { UserProfile } from '@/lib/supabase'
+
+export interface UserStatsSummary {
+  total: number
+  byRole: Record<UserProfile['role'], number>
+}


### PR DESCRIPTION
## Summary
- add reusable type definitions for offline queue payloads, eligibility assessments, and user stats
- update admin views, eligibility dashboard, and API hooks to use typed Application/UserProfile data instead of `any`
- tighten offline sync and shared services with structured payload guards and safer security helpers

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68cd4d3602f88332a8f6f9b343ee7bf1