### PR TITLE
Fix Vercel build failures for admin applications table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "react-hook-form": "^7.53.0",
         "react-intersection-observer": "^9.16.0",
         "react-router-dom": "^6.26.1",
-        "react-window": "^2.1.1",
+        "react-window": "^1.8.10",
         "tailwind-merge": "^2.5.2",
         "tailwindcss": "^3.4.10",
         "tailwindcss-animate": "^1.0.7",
@@ -10341,6 +10341,12 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -11601,13 +11607,20 @@
       }
     },
     "node_modules/react-window": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-window/-/react-window-2.1.1.tgz",
-      "integrity": "sha512-Wx5yHri8G1nFxImnJRkEEKtRTnG3cWaqknUJyYvgisQtl1mw/d8LQmLXfuKxpn2dY8IwDn5mCIuxm2NVyIvgVQ==",
+      "version": "1.8.10",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.10.tgz",
+      "integrity": "sha512-Y0Cx+dnU6NLa5/EvoHukUD0BklJ8qITCtVEPY1C/nL8wwoZ0b5aEw8Ff1dOVHw7fCzMt55XfJDd8S8W8LCaUCg==",
       "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
       "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "react-hook-form": "^7.53.0",
     "react-intersection-observer": "^9.16.0",
     "react-router-dom": "^6.26.1",
-    "react-window": "^2.1.1",
+    "react-window": "^1.8.10",
     "tailwind-merge": "^2.5.2",
     "tailwindcss": "^3.4.10",
     "tailwindcss-animate": "^1.0.7",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,6 +41,7 @@ export default defineConfig(({ mode }) => {
           ]
         },
         workbox: {
+          maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
           globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
           skipWaiting: true,
           clientsClaim: true,


### PR DESCRIPTION
## Summary
- pin `react-window` to the 1.x API so the admin applications table can import `FixedSizeList`
- raise Workbox's maximum precache size to stop PWA build failures caused by the large vendor chunk

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd6e42b300833285705ee579c27e22