### PR TITLE
Enable opt-out defaults for SMS and WhatsApp notifications

### DIFF
--- a/api/notifications.js
+++ b/api/notifications.js
@@ -478,8 +478,8 @@ function normalizePreferencesRecord(record = {}) {
 function normalizeChannelPreferences(channels) {
   const defaultConfig = [
     { type: 'email', enabled: true, priority: 1 },
-    { type: 'sms', enabled: false, priority: 2 },
-    { type: 'whatsapp', enabled: false, priority: 3 },
+    { type: 'sms', enabled: true, priority: 2 },
+    { type: 'whatsapp', enabled: true, priority: 3 },
     { type: 'in_app', enabled: true, priority: 4 }
   ]
 
@@ -492,13 +492,15 @@ function normalizeChannelPreferences(channels) {
       }
 
       const type = String(entry.type)
+      const existing = channelMap.get(type) || { type, enabled: true, priority: defaultConfig.length + 1 }
+      const hasExplicitEnabled = typeof entry.enabled === 'boolean'
       const normalized = {
         type,
-        enabled: Boolean(entry.enabled),
-        priority: Number.isFinite(entry.priority) ? Number(entry.priority) : channelMap.get(type)?.priority ?? defaultConfig.length + 1
+        enabled: hasExplicitEnabled ? entry.enabled : existing.enabled,
+        priority: Number.isFinite(entry.priority) ? Number(entry.priority) : existing.priority
       }
 
-      channelMap.set(type, { ...channelMap.get(type), ...normalized })
+      channelMap.set(type, { ...existing, ...normalized })
     })
   }
 
@@ -573,6 +575,11 @@ function hasExplicitOptIn(preferences, channel) {
 
   return true
 }
+
+module.exports.normalizePreferencesRecord = normalizePreferencesRecord
+module.exports.normalizeChannelPreferences = normalizeChannelPreferences
+module.exports.updateChannelEnabledState = updateChannelEnabledState
+module.exports.hasExplicitOptIn = hasExplicitOptIn
 
 function ensureTwilioConfiguration(channel) {
   if (!TWILIO_ACCOUNT_SID || !TWILIO_AUTH_TOKEN) {

--- a/src/pages/student/NotificationSettings.tsx
+++ b/src/pages/student/NotificationSettings.tsx
@@ -66,7 +66,7 @@ function formatTimestamp(timestamp?: string | null) {
 
 function resolveChannelEntry(preferences: NotificationPreferencesResponse | null, channel: ChannelKey) {
   const entry = preferences?.channels?.find(item => item.type === channel)
-  return entry ?? { type: channel, enabled: false, priority: channel === 'sms' ? 2 : 3 }
+  return entry ?? { type: channel, enabled: true, priority: channel === 'sms' ? 2 : 3 }
 }
 
 function isChannelOptedIn(preferences: NotificationPreferencesResponse | null, channel: ChannelKey) {
@@ -82,7 +82,15 @@ function isChannelOptedIn(preferences: NotificationPreferencesResponse | null, c
   const optInAt = channel === 'sms' ? preferences.sms_opt_in_at : preferences.whatsapp_opt_in_at
   const optOutAt = channel === 'sms' ? preferences.sms_opt_out_at : preferences.whatsapp_opt_out_at
 
-  return Boolean(optInAt) && !optOutAt
+  if (optOutAt) {
+    return false
+  }
+
+  if (optInAt) {
+    return true
+  }
+
+  return true
 }
 
 export default function NotificationSettings() {
@@ -465,3 +473,5 @@ export default function NotificationSettings() {
     </div>
   )
 }
+
+export { resolveChannelEntry, isChannelOptedIn }

--- a/src/pages/student/__tests__/NotificationSettings.utils.test.ts
+++ b/src/pages/student/__tests__/NotificationSettings.utils.test.ts
@@ -1,0 +1,58 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+
+process.env.VITE_SUPABASE_URL = process.env.VITE_SUPABASE_URL ?? 'http://localhost:54321'
+process.env.VITE_SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY ?? 'anon-key'
+
+let resolveChannelEntry: (preferences: any, channel: 'sms' | 'whatsapp') => { type: string; enabled: boolean; priority: number }
+let isChannelOptedIn: (preferences: any, channel: 'sms' | 'whatsapp') => boolean
+
+beforeAll(async () => {
+  ;({ resolveChannelEntry, isChannelOptedIn } = await import('@/pages/student/NotificationSettings'))
+})
+
+const basePreferences = {
+  channels: [
+    { type: 'sms', enabled: true, priority: 2 },
+    { type: 'whatsapp', enabled: true, priority: 3 }
+  ],
+  sms_opt_in_at: null,
+  sms_opt_out_at: null,
+  whatsapp_opt_in_at: null,
+  whatsapp_opt_out_at: null
+} as const
+
+describe('NotificationSettings helpers', () => {
+  it('defaults to enabled entries for SMS and WhatsApp when none exist', () => {
+    const smsEntry = resolveChannelEntry(null, 'sms')
+    const whatsappEntry = resolveChannelEntry(null, 'whatsapp')
+
+    expect(smsEntry.enabled).toBe(true)
+    expect(whatsappEntry.enabled).toBe(true)
+  })
+
+  it('treats enabled channels without opt-outs as opted in', () => {
+    expect(isChannelOptedIn({ ...basePreferences } as any, 'sms')).toBe(true)
+    expect(isChannelOptedIn({ ...basePreferences } as any, 'whatsapp')).toBe(true)
+  })
+
+  it('respects opt-out state even when the channel is present', () => {
+    const smsOptOutPreferences = {
+      ...basePreferences,
+      channels: basePreferences.channels.map(channel =>
+        channel.type === 'sms' ? { ...channel, enabled: false } : channel
+      ),
+      sms_opt_out_at: '2024-01-01T00:00:00Z'
+    } as any
+
+    const whatsappOptOutPreferences = {
+      ...basePreferences,
+      channels: basePreferences.channels.map(channel =>
+        channel.type === 'whatsapp' ? { ...channel, enabled: false } : channel
+      ),
+      whatsapp_opt_out_at: '2024-02-01T00:00:00Z'
+    } as any
+
+    expect(isChannelOptedIn(smsOptOutPreferences, 'sms')).toBe(false)
+    expect(isChannelOptedIn(whatsappOptOutPreferences, 'whatsapp')).toBe(false)
+  })
+})

--- a/tests/unit/api/notification-preferences.test.ts
+++ b/tests/unit/api/notification-preferences.test.ts
@@ -1,0 +1,93 @@
+import { createRequire } from 'module'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const nodeRequire = createRequire(import.meta.url)
+
+const handlerModulePath = nodeRequire.resolve('../../../api/notifications.js')
+const supabaseModulePath = nodeRequire.resolve('../../../api/_lib/supabaseClient.js')
+const auditLoggerModulePath = nodeRequire.resolve('../../../api/_lib/auditLogger.js')
+const rateLimiterModulePath = nodeRequire.resolve('../../../api/_lib/rateLimiter.js')
+const userConsentModulePath = nodeRequire.resolve('../../../api/_lib/userConsent.js')
+const nodeFetchModulePath = nodeRequire.resolve('node-fetch')
+
+function registerMock(modulePath: string, exports: unknown) {
+  nodeRequire.cache[modulePath] = {
+    id: modulePath,
+    filename: modulePath,
+    loaded: true,
+    exports
+  }
+}
+
+function clearModule(modulePath: string) {
+  delete nodeRequire.cache[modulePath]
+}
+
+function loadNotificationsModule() {
+  clearModule(handlerModulePath)
+  return nodeRequire(handlerModulePath) as {
+    normalizeChannelPreferences: (channels?: Array<{ type: string; enabled?: boolean; priority?: number }>) => Array<{
+      type: string
+      enabled: boolean
+      priority: number
+    }>
+  }
+}
+
+describe('notification channel normalization', () => {
+  beforeEach(() => {
+    const fetchMock = Object.assign(vi.fn(), {
+      Response: class {},
+      Headers: class {}
+    })
+
+    registerMock(nodeFetchModulePath, fetchMock)
+    registerMock(supabaseModulePath, {
+      supabaseAdminClient: { from: vi.fn() },
+      getUserFromRequest: vi.fn()
+    })
+    registerMock(auditLoggerModulePath, { logAuditEvent: vi.fn() })
+    registerMock(rateLimiterModulePath, {
+      checkRateLimit: vi.fn(async () => ({ isLimited: false })),
+      buildRateLimitKey: vi.fn(() => 'test-rate-key'),
+      getLimiterConfig: vi.fn(() => ({})),
+      attachRateLimitHeaders: vi.fn()
+    })
+    registerMock(userConsentModulePath, {
+      hasActiveConsent: vi.fn(async () => ({ active: true }))
+    })
+  })
+
+  afterEach(() => {
+    ;[
+      handlerModulePath,
+      nodeFetchModulePath,
+      supabaseModulePath,
+      auditLoggerModulePath,
+      rateLimiterModulePath,
+      userConsentModulePath
+    ].forEach(clearModule)
+  })
+
+  it('enables SMS and WhatsApp by default when no record exists', () => {
+    const notifications = loadNotificationsModule()
+    const channels = notifications.normalizeChannelPreferences(undefined)
+
+    const sms = channels.find(channel => channel.type === 'sms')
+    const whatsapp = channels.find(channel => channel.type === 'whatsapp')
+
+    expect(sms?.enabled).toBe(true)
+    expect(whatsapp?.enabled).toBe(true)
+  })
+
+  it('retains persisted opt-outs when normalizing stored records', () => {
+    const notifications = loadNotificationsModule()
+    const channels = notifications.normalizeChannelPreferences([
+      { type: 'sms', enabled: false, priority: 2 },
+      { type: 'whatsapp', enabled: false, priority: 3 }
+    ])
+
+    expect(channels.find(channel => channel.type === 'sms')?.enabled).toBe(false)
+    expect(channels.find(channel => channel.type === 'whatsapp')?.enabled).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- default SMS and WhatsApp notification channels to enabled while preserving stored opt-out states
- update the student notification settings page to surface the new defaults when no explicit opt-out exists
- add unit coverage to verify normalization keeps opt-outs and the UI helpers treat default channels as enabled

## Testing
- npx vitest run tests/unit/api/notification-preferences.test.ts src/pages/student/__tests__/NotificationSettings.utils.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cdad58455083328707838a1172c13a