### PR TITLE
feat(admin): add application detail modal workflow

### DIFF
--- a/src/components/admin/applications/index.ts
+++ b/src/components/admin/applications/index.ts
@@ -1,4 +1,5 @@
 export { FiltersPanel } from './FiltersPanel'
 export { MetricsHeader } from './MetricsHeader'
 export { ApplicationsTable } from './ApplicationsTable'
+export type { ApplicationSummary } from './ApplicationsTable'
 export { ApplicationsSkeleton } from './ApplicationsSkeleton'


### PR DESCRIPTION
## Summary
- integrate the application detail modal into the admin applications page with selection state, detail fetching, and inline actions
- extend the applications table to expose a row selection callback and provide a "View details" action alongside existing document links
- enhance the application detail modal with loading feedback and payment status controls so admins can verify or reset payments without leaving the page

## Testing
- npx eslint src/components/admin/applications/ApplicationsTable.tsx src/components/admin/applications/ApplicationDetailModal.tsx src/pages/admin/Applications.tsx
- npm run lint *(fails because of numerous pre-existing lint errors in other files)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb0671ec083329b30793deb59cb05