### PR TITLE
feat: lazy-load supabase client

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { Navigate } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
-import { supabase } from '@/lib/supabase'
+import { getSupabaseClient } from '@/lib/supabase'
 
 interface ProtectedRouteProps {
   children: React.ReactNode
@@ -13,22 +13,34 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
   const [sessionChecked, setSessionChecked] = useState(false)
 
   useEffect(() => {
-    // Double-check session on mount
+    let active = true
+
     const checkSession = async () => {
       try {
+        const supabase = await getSupabaseClient()
         const { data: { session } } = await supabase.auth.getSession()
+        if (!active) return
+
         if (session) {
           console.log('Session validated in ProtectedRoute')
         }
       } catch (error) {
-        console.error('Session check failed:', error)
+        if (active) {
+          console.error('Session check failed:', error)
+        }
       } finally {
-        setSessionChecked(true)
+        if (active) {
+          setSessionChecked(true)
+        }
       }
     }
-    
+
     if (!loading) {
       checkSession()
+    }
+
+    return () => {
+      active = false
     }
   }, [loading])
 

--- a/src/hooks/auth/useProfileQuery.ts
+++ b/src/hooks/auth/useProfileQuery.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { User } from '@supabase/supabase-js'
+import type { User } from '@supabase/supabase-js'
 import { useAuth } from '@/contexts/AuthContext'
 import { getSupabaseClient, UserProfile } from '@/lib/supabase'
 import { sanitizeForDisplay } from '@/lib/sanitize'
@@ -63,7 +63,7 @@ function parseSignupData(user: User) {
 
 async function createUserProfile(user: User): Promise<UserProfile | null> {
   try {
-    const supabase = getSupabaseClient()
+    const supabase = await getSupabaseClient()
     const signupData = parseSignupData(user)
     const metadata = user.user_metadata || {}
 
@@ -118,7 +118,7 @@ export function useProfileQuery(options: UseProfileQueryOptions = {}): ProfileQu
     queryFn: async () => {
       if (!user) return null
 
-      const supabase = getSupabaseClient()
+      const supabase = await getSupabaseClient()
       const { data, error } = await supabase
         .from('user_profiles')
         .select('*')
@@ -148,7 +148,7 @@ export function useProfileQuery(options: UseProfileQueryOptions = {}): ProfileQu
         throw new Error('User not authenticated')
       }
 
-      const supabase = getSupabaseClient()
+      const supabase = await getSupabaseClient()
 
       const allowedFields = [
         'full_name',

--- a/src/hooks/auth/useRoleQuery.ts
+++ b/src/hooks/auth/useRoleQuery.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { User } from '@supabase/supabase-js'
+import type { User } from '@supabase/supabase-js'
 import { useAuth } from '@/contexts/AuthContext'
 import { getSupabaseClient } from '@/lib/supabase'
 import { sanitizeForLog } from '@/lib/security'
@@ -56,7 +56,7 @@ export function useRoleQuery(options: UseRoleQueryOptions = {}): RoleQueryResult
         }
       }
 
-      const supabase = getSupabaseClient()
+      const supabase = await getSupabaseClient()
       const { data: { session } } = await supabase.auth.getSession()
       const accessToken = session?.access_token
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,5 +1,5 @@
 import type { Session } from '@supabase/supabase-js'
-import { supabase } from './supabase'
+import { getSupabaseClient } from './supabase'
 import { ReportExportData, ReportFormat } from './reportExports'
 import { isReportManagerRole } from '@/lib/auth/roles'
 import { sanitizeForLog } from './security'
@@ -57,8 +57,13 @@ export interface AutomatedReport {
 }
 
 export class AnalyticsService {
+  private static async getClient() {
+    return getSupabaseClient()
+  }
+
   // Ensure user is authenticated before making requests
   static async ensureAuthenticated() {
+    const supabase = await this.getClient()
     const { data: { session } } = await supabase.auth.getSession()
     if (!session?.access_token) {
       throw new Error('User not authenticated - JWT token missing')
@@ -120,8 +125,9 @@ export class AnalyticsService {
   // Event Tracking
   static async trackEvent(event: AnalyticsEvent) {
     try {
+      const supabase = await this.getClient()
       await this.ensureAuthenticated()
-      
+
       const { error } = await supabase
         .from('user_engagement_metrics')
         .insert({
@@ -141,6 +147,7 @@ export class AnalyticsService {
 
   // Application Statistics CRUD
   static async createApplicationStats(stats: Omit<ApplicationStats, 'id'>) {
+    const supabase = await this.getClient()
     await this.ensureReportManagerAccess()
 
     const { data, error } = await supabase
@@ -163,6 +170,7 @@ export class AnalyticsService {
   }
 
   static async updateApplicationStats(id: string, stats: Partial<ApplicationStats>) {
+    const supabase = await this.getClient()
     await this.ensureReportManagerAccess()
 
     const { data, error } = await supabase
@@ -185,6 +193,7 @@ export class AnalyticsService {
   }
 
   static async deleteApplicationStats(id: string) {
+    const supabase = await this.getClient()
     await this.ensureReportManagerAccess()
 
     const { error } = await supabase
@@ -196,6 +205,7 @@ export class AnalyticsService {
   }
 
   static async getApplicationStatistics(startDate: string, endDate: string): Promise<ApplicationStats[]> {
+    const supabase = await this.getClient()
     const { data, error } = await supabase
       .from('application_statistics')
       .select('*')
@@ -219,6 +229,7 @@ export class AnalyticsService {
 
   // Program Analytics CRUD
   static async createProgramAnalytics(analytics: Omit<ProgramAnalytics, 'id' | 'programName'>) {
+    const supabase = await this.getClient()
     await this.ensureReportManagerAccess()
 
     const { data, error } = await supabase
@@ -239,6 +250,7 @@ export class AnalyticsService {
   }
 
   static async updateProgramAnalytics(id: string, analytics: Partial<ProgramAnalytics>) {
+    const supabase = await this.getClient()
     await this.ensureReportManagerAccess()
 
     const { data, error } = await supabase
@@ -260,6 +272,7 @@ export class AnalyticsService {
   }
 
   static async deleteProgramAnalytics(id: string) {
+    const supabase = await this.getClient()
     await this.ensureReportManagerAccess()
 
     const { error } = await supabase
@@ -271,6 +284,8 @@ export class AnalyticsService {
   }
 
   static async getProgramAnalytics(programId?: string): Promise<ProgramAnalytics[]> {
+    const supabase = await this.getClient()
+
     let query = supabase
       .from('program_analytics')
       .select(`
@@ -299,6 +314,7 @@ export class AnalyticsService {
 
   // Eligibility Analytics CRUD
   static async createEligibilityAnalytics(analytics: Omit<EligibilityAnalytics, 'id'>) {
+    const supabase = await this.getClient()
     await this.ensureReportManagerAccess()
 
     const { data, error } = await supabase
@@ -319,6 +335,7 @@ export class AnalyticsService {
   }
 
   static async updateEligibilityAnalytics(id: string, analytics: Partial<EligibilityAnalytics>) {
+    const supabase = await this.getClient()
     await this.ensureReportManagerAccess()
 
     const { data, error } = await supabase
@@ -340,6 +357,7 @@ export class AnalyticsService {
   }
 
   static async deleteEligibilityAnalytics(id: string) {
+    const supabase = await this.getClient()
     await this.ensureReportManagerAccess()
 
     const { error } = await supabase
@@ -351,6 +369,7 @@ export class AnalyticsService {
   }
 
   static async getEligibilityAnalytics(startDate: string, endDate: string): Promise<EligibilityAnalytics[]> {
+    const supabase = await this.getClient()
     const { data, error } = await supabase
       .from('eligibility_analytics')
       .select('*')
@@ -372,6 +391,7 @@ export class AnalyticsService {
 
   // Automated Reports CRUD
   static async createAutomatedReport(report: Omit<AutomatedReport, 'id' | 'createdAt'>) {
+    const supabase = await this.getClient()
     await this.ensureReportManagerAccess()
 
     const { data: { user } } = await supabase.auth.getUser()

--- a/src/lib/lazySupabase.ts
+++ b/src/lib/lazySupabase.ts
@@ -1,0 +1,201 @@
+import type { SupabaseClient, SupportedStorage } from '@supabase/supabase-js'
+import { sanitizeForLog } from './security'
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Missing Supabase environment variables')
+}
+
+const AUTH_STORAGE_KEY = 'mihas-auth-token'
+
+export interface SupabaseFactoryOptions {
+  storage?: SupportedStorage
+}
+
+let supabaseClient: SupabaseClient | null = null
+let clientPromise: Promise<SupabaseClient> | null = null
+let usingServerStorage = false
+let authHandlersInitialized = false
+let sessionInterval: NodeJS.Timeout | null = null
+let refreshRetryCount = 0
+
+const MAX_REFRESH_RETRIES = 3
+
+function createMemoryStorage(): SupportedStorage {
+  const store = new Map<string, string>()
+
+  return {
+    getItem: key => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value)
+    },
+    removeItem: key => {
+      store.delete(key)
+    },
+    isServer: true
+  }
+}
+
+function resolveStorage(adapter?: SupportedStorage) {
+  if (adapter) {
+    return { storage: adapter, isServerStorage: adapter.isServer === true }
+  }
+
+  if (typeof window !== 'undefined' && window.localStorage) {
+    const localStorageAdapter: SupportedStorage = {
+      getItem: key => window.localStorage.getItem(key),
+      setItem: (key, value) => {
+        window.localStorage.setItem(key, value)
+      },
+      removeItem: key => {
+        window.localStorage.removeItem(key)
+      },
+      isServer: false
+    }
+    return { storage: localStorageAdapter, isServerStorage: false }
+  }
+
+  const memoryStorage = createMemoryStorage()
+  return { storage: memoryStorage, isServerStorage: true }
+}
+
+async function instantiateClient(options: SupabaseFactoryOptions = {}) {
+  const { storage, isServerStorage } = resolveStorage(options.storage)
+  const shouldRecreateClient = !supabaseClient || (!isServerStorage && usingServerStorage)
+
+  if (shouldRecreateClient) {
+    if (sessionInterval) {
+      clearInterval(sessionInterval)
+      sessionInterval = null
+    }
+
+    const { createClient } = await import('@supabase/supabase-js')
+
+    supabaseClient = createClient(supabaseUrl, supabaseAnonKey, {
+      auth: {
+        autoRefreshToken: true,
+        persistSession: true,
+        detectSessionInUrl: false,
+        flowType: 'pkce',
+        storage,
+        storageKey: AUTH_STORAGE_KEY,
+        debug: false
+      },
+      global: {
+        headers: {
+          'x-client-info': 'mihas-app@1.0.0'
+        },
+        fetch: (url, options = {}) => {
+          const isAuthRequest = url.includes('/auth/') || url.includes('/token')
+          const timeout = isAuthRequest ? 30000 : 8000
+
+          const controller = new AbortController()
+          const timeoutId = setTimeout(() => controller.abort(), timeout)
+
+          return fetch(url, {
+            ...options,
+            signal: controller.signal
+          }).finally(() => {
+            clearTimeout(timeoutId)
+          })
+        }
+      }
+    })
+
+    usingServerStorage = isServerStorage
+    authHandlersInitialized = false
+    refreshRetryCount = 0
+  }
+
+  if (typeof window !== 'undefined' && supabaseClient && !authHandlersInitialized) {
+    initializeBrowserAuthHandlers(supabaseClient, storage)
+  }
+
+  return supabaseClient!
+}
+
+function initializeBrowserAuthHandlers(client: SupabaseClient, storage: SupportedStorage) {
+  if (authHandlersInitialized || typeof window === 'undefined') {
+    return
+  }
+
+  client.auth.onAuthStateChange(async (event, session) => {
+    console.log('Auth event:', sanitizeForLog(event))
+
+    if (event === 'TOKEN_REFRESHED') {
+      console.log('Token refreshed successfully')
+      refreshRetryCount = 0
+    }
+
+    if (event === 'SIGNED_OUT') {
+      console.log('User signed out')
+      await Promise.resolve(storage.removeItem(AUTH_STORAGE_KEY))
+    }
+
+    if (event === 'SIGNED_IN' && session) {
+      console.log('User signed in:', sanitizeForLog(session.user?.id || ''))
+      startSessionMonitoring(client)
+    }
+  })
+
+  authHandlersInitialized = true
+}
+
+function startSessionMonitoring(client: SupabaseClient) {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  if (sessionInterval) clearInterval(sessionInterval)
+
+  sessionInterval = setInterval(async () => {
+    try {
+      const { data: { session }, error } = await client.auth.getSession()
+
+      if (!session || error) return
+
+      const timeUntilExpiry = session.expires_at! * 1000 - Date.now()
+      const fiveMinutes = 5 * 60 * 1000
+
+      if (timeUntilExpiry < fiveMinutes && timeUntilExpiry > 0) {
+        await retryTokenRefresh(client)
+      }
+    } catch (error) {
+      console.warn('Session check failed:', error)
+    }
+  }, 60000)
+}
+
+async function retryTokenRefresh(client: SupabaseClient) {
+  for (let i = 0; i < MAX_REFRESH_RETRIES; i++) {
+    try {
+      const { error } = await client.auth.refreshSession()
+      if (!error) {
+        console.log('Token refresh successful')
+        return
+      }
+      console.warn(`Token refresh attempt ${i + 1} failed:`, error.message)
+    } catch (error) {
+      console.warn(`Token refresh attempt ${i + 1} error:`, error)
+    }
+
+    if (i < MAX_REFRESH_RETRIES - 1) {
+      await new Promise(resolve => setTimeout(resolve, 2000 * (i + 1)))
+    }
+  }
+  console.error('All token refresh attempts failed')
+}
+
+export async function loadSupabaseClient(options: SupabaseFactoryOptions = {}) {
+  if (options.storage) {
+    return instantiateClient(options)
+  }
+
+  if (!clientPromise) {
+    clientPromise = instantiateClient(options)
+  }
+
+  return clientPromise
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,398 +1,81 @@
-import { createClient, type SupabaseClient, type SupportedStorage } from '@supabase/supabase-js'
-import { sanitizeForLog } from './security'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { loadSupabaseClient, type SupabaseFactoryOptions } from './lazySupabase'
 
-// Supabase project configuration from environment variables
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+export * from './supabaseTypes'
+export type { SupabaseFactoryOptions } from './lazySupabase'
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error('Missing Supabase environment variables')
-}
+let cachedClient: SupabaseClient | null = null
 
-const AUTH_STORAGE_KEY = 'mihas-auth-token'
-
-type SupabaseFactoryOptions = {
-  storage?: SupportedStorage
-}
-
-let supabaseClient: SupabaseClient | null = null
-let usingServerStorage = false
-let authHandlersInitialized = false
-let sessionInterval: NodeJS.Timeout | null = null
-let refreshRetryCount = 0
-
-const MAX_REFRESH_RETRIES = 3
-
-function createMemoryStorage(): SupportedStorage {
-  const store = new Map<string, string>()
-
-  return {
-    getItem: key => store.get(key) ?? null,
-    setItem: (key, value) => {
-      store.set(key, value)
-    },
-    removeItem: key => {
-      store.delete(key)
-    },
-    isServer: true
-  }
-}
-
-function resolveStorage(adapter?: SupportedStorage) {
-  if (adapter) {
-    return { storage: adapter, isServerStorage: adapter.isServer === true }
+export async function getSupabaseClient(options: SupabaseFactoryOptions = {}) {
+  if (options.storage) {
+    cachedClient = await loadSupabaseClient(options)
+    return cachedClient
   }
 
-  if (typeof window !== 'undefined' && window.localStorage) {
-    return { storage: window.localStorage, isServerStorage: false }
+  if (!cachedClient) {
+    cachedClient = await loadSupabaseClient()
   }
 
-  const memoryStorage = createMemoryStorage()
-  return { storage: memoryStorage, isServerStorage: true }
+  return cachedClient
 }
 
-export function createSupabaseClient(options: SupabaseFactoryOptions = {}): SupabaseClient {
-  const { storage, isServerStorage } = resolveStorage(options.storage)
-  const shouldRecreateClient =
-    !supabaseClient || (!isServerStorage && usingServerStorage)
+type SupabaseCallable = (
+  options?: SupabaseFactoryOptions
+) => Promise<SupabaseClient>
 
-  if (shouldRecreateClient) {
-    if (sessionInterval) {
-      clearInterval(sessionInterval)
-      sessionInterval = null
-    }
+const supabaseCallable: SupabaseCallable = async (options: SupabaseFactoryOptions = {}) => {
+  return getSupabaseClient(options)
+}
 
-    supabaseClient = createClient(supabaseUrl, supabaseAnonKey, {
-      auth: {
-        autoRefreshToken: true,
-        persistSession: true,
-        detectSessionInUrl: false,
-        flowType: 'pkce',
-        storage,
-        storageKey: AUTH_STORAGE_KEY,
-        debug: false
-      },
-      global: {
-        headers: {
-          'x-client-info': 'mihas-app@1.0.0'
-        },
-        fetch: (url, options = {}) => {
-          // Longer timeout for auth requests
-          const isAuthRequest = url.includes('/auth/') || url.includes('/token')
-          const timeout = isAuthRequest ? 30000 : 8000
+function resolvePath(client: SupabaseClient, path: PropertyKey[]) {
+  return path.reduce((acc, key) => (acc as any)[key], client as any)
+}
 
-          const controller = new AbortController()
-          const timeoutId = setTimeout(() => controller.abort(), timeout)
-
-          return fetch(url, {
-            ...options,
-            signal: controller.signal
-          }).finally(() => {
-            clearTimeout(timeoutId)
-          })
-        }
+function createPropertyProxy(path: PropertyKey[]): any {
+  const proxy = new Proxy(function () {}, {
+    async apply(_target, _thisArg, args) {
+      const client = await getSupabaseClient()
+      const value = resolvePath(client, path)
+      if (typeof value === 'function') {
+        const parent = path.length > 1 ? resolvePath(client, path.slice(0, -1)) : client
+        return value.apply(parent, args)
       }
-    })
-
-    usingServerStorage = isServerStorage
-    authHandlersInitialized = false
-    refreshRetryCount = 0
-  }
-
-  if (typeof window !== 'undefined' && supabaseClient && !authHandlersInitialized) {
-    initializeBrowserAuthHandlers(supabaseClient, storage)
-  }
-
-  return supabaseClient!
-}
-
-export const getSupabaseClient = createSupabaseClient
-
-function initializeBrowserAuthHandlers(client: SupabaseClient, storage: SupportedStorage) {
-  if (authHandlersInitialized || typeof window === 'undefined') {
-    return
-  }
-
-  client.auth.onAuthStateChange(async (event, session) => {
-    console.log('Auth event:', sanitizeForLog(event))
-
-    if (event === 'TOKEN_REFRESHED') {
-      console.log('Token refreshed successfully')
-      refreshRetryCount = 0
-    }
-
-    if (event === 'SIGNED_OUT') {
-      console.log('User signed out')
-      await Promise.resolve(storage.removeItem(AUTH_STORAGE_KEY))
-    }
-
-    if (event === 'SIGNED_IN' && session) {
-      console.log('User signed in:', sanitizeForLog(session.user?.id || ''))
-      startSessionMonitoring(client)
+      return value
+    },
+    get(_target, prop) {
+      if (prop === 'then') {
+        return undefined
+      }
+      return createPropertyProxy([...path, prop])
+    },
+    set(_target, prop, value) {
+      getSupabaseClient().then(client => {
+        const target = resolvePath(client, path)
+        if (target && typeof target === 'object') {
+          (target as any)[prop] = value
+        }
+      })
+      return true
     }
   })
 
-  authHandlersInitialized = true
+  return proxy
 }
 
-// Session monitoring with retry logic
-function startSessionMonitoring(client: SupabaseClient) {
-  if (typeof window === 'undefined') {
-    return
-  }
-
-  if (sessionInterval) clearInterval(sessionInterval)
-
-  sessionInterval = setInterval(async () => {
-    try {
-      const { data: { session }, error } = await client.auth.getSession()
-
-      if (!session || error) return
-
-      const timeUntilExpiry = (session.expires_at! * 1000) - Date.now()
-      const fiveMinutes = 5 * 60 * 1000
-
-      if (timeUntilExpiry < fiveMinutes && timeUntilExpiry > 0) {
-        await retryTokenRefresh(client)
-      }
-    } catch (error) {
-      console.warn('Session check failed:', error)
-    }
-  }, 60000)
-}
-
-async function retryTokenRefresh(client: SupabaseClient) {
-  for (let i = 0; i < MAX_REFRESH_RETRIES; i++) {
-    try {
-      const { error } = await client.auth.refreshSession()
-      if (!error) {
-        console.log('Token refresh successful')
-        return
-      }
-      console.warn(`Token refresh attempt ${i + 1} failed:`, error.message)
-    } catch (error) {
-      console.warn(`Token refresh attempt ${i + 1} error:`, error)
-    }
-
-    if (i < MAX_REFRESH_RETRIES - 1) {
-      await new Promise(resolve => setTimeout(resolve, 2000 * (i + 1))) // Exponential backoff
-    }
-  }
-  console.error('All token refresh attempts failed')
-}
-
-export const supabase = new Proxy({}, {
+export const supabase = new Proxy(supabaseCallable, {
+  apply(_target, _thisArg, args) {
+    return supabaseCallable(...(args as [SupabaseFactoryOptions?]))
+  },
   get(_target, prop) {
-    const client = createSupabaseClient()
-    const value = (client as any)[prop]
-    if (typeof value === 'function') {
-      return value.bind(client)
+    if (prop === 'then') {
+      return undefined
     }
-    return value
+    return createPropertyProxy([prop])
   },
   set(_target, prop, value) {
-    const client = createSupabaseClient()
-    (client as any)[prop] = value
+    getSupabaseClient().then(client => {
+      (client as any)[prop] = value
+    })
     return true
   }
-}) as SupabaseClient
-
-// Database type definitions (keeping existing types)
-export interface UserProfile {
-  id: string
-  user_id: string
-  full_name?: string
-  email?: string
-  phone?: string
-  role: string
-  date_of_birth?: string
-  sex?: string
-  nationality?: string
-  address?: string
-  city?: string
-  next_of_kin_name?: string
-  next_of_kin_phone?: string
-  avatar_url?: string
-  bio?: string
-  created_at: string
-  updated_at: string
-}
-
-export interface Institution {
-  id: string
-  slug: string
-  name: string
-  full_name: string
-  description?: string
-  logo_url?: string
-  contact_email?: string
-  contact_phone?: string
-  address?: string
-  is_active: boolean
-  created_at: string
-  updated_at: string
-}
-
-export interface Program {
-  id: string
-  name: string
-  description?: string
-  duration_years: number
-  department?: string
-  qualification_level?: string
-  entry_requirements?: string
-  fees_per_year?: number
-  institution_id: string
-  is_active: boolean
-  created_by?: string
-  created_at: string
-  updated_at: string
-}
-
-export interface Intake {
-  id: string
-  name: string
-  year: number
-  semester?: string
-  start_date: string
-  end_date: string
-  application_deadline: string
-  total_capacity: number
-  available_spots: number
-  is_active: boolean
-  created_by?: string
-  created_at: string
-  updated_at: string
-}
-
-export interface Application {
-  id: string
-  application_number: string
-  user_id: string
-  
-  // Step 1: Basic KYC
-  full_name: string
-  nrc_number?: string
-  passport_number?: string
-  date_of_birth: string
-  sex: 'Male' | 'Female'
-  phone: string
-  email: string
-  residence_town: string
-  next_of_kin_name?: string
-  next_of_kin_phone?: string
-  program: 'Clinical Medicine' | 'Environmental Health' | 'Registered Nursing'
-  intake: string
-  institution: 'KATC' | 'MIHAS'
-  
-  // Step 2: Education & Documents
-  result_slip_url?: string
-  extra_kyc_url?: string
-  
-  // Step 3: Payment
-  application_fee: number
-  payment_method?: string
-  payer_name?: string
-  payer_phone?: string
-  amount?: number
-  paid_at?: string
-  momo_ref?: string
-  pop_url?: string
-  payment_status: 'pending_review' | 'verified' | 'rejected'
-  payment_verified_at?: string | null
-  payment_verified_by?: string | null
-
-  // Step 4: Status tracking
-  status: 'draft' | 'submitted' | 'under_review' | 'approved' | 'rejected'
-  submitted_at?: string
-  
-  // Tracking
-  public_tracking_code?: string
-  created_at: string
-  updated_at: string
-  
-  // Admin fields
-  reviewed_by?: string
-  reviewed_at?: string
-  review_started_at?: string
-  review_notes?: string
-  decision_reason?: string
-  decision_date?: string
-}
-
-export interface ApplicationDocument {
-  id: string
-  application_id: string
-  document_type: string
-  document_name: string
-  file_url: string
-  file_size?: number
-  mime_type?: string
-  system_generated: boolean
-  verification_status: 'pending' | 'verified' | 'rejected'
-  verified_by?: string
-  verified_at?: string
-  verification_notes?: string
-  uploaded_at: string
-  created_at: string
-  updated_at: string
-}
-
-export interface ApplicationWithDetails extends Application {
-  programs?: Program
-  intakes?: Intake
-  documents?: ApplicationDocument[]
-}
-
-export interface Grade12Subject {
-  id: string
-  name: string
-  code?: string
-  is_active: boolean
-  created_at: string
-}
-
-export interface ApplicationGrade {
-  id: string
-  application_id: string
-  subject_id: string
-  grade: number
-  created_at: string
-}
-
-export interface UserRole {
-  id: string
-  user_id: string
-  role: string
-  permissions: string[]
-  department?: string
-  assigned_by?: string
-  is_active: boolean
-  assigned_at: string
-  created_at: string
-  updated_at: string
-}
-
-export interface SystemSetting {
-  id: string
-  setting_key: string
-  setting_value?: string
-  setting_type: string
-  description?: string
-  is_public: boolean
-  updated_by?: string
-  created_at: string
-  updated_at: string
-}
-
-export interface ApplicationDraft {
-  id: string
-  user_id: string
-  form_data: Record<string, any>
-  uploaded_files: any[]
-  current_step: number
-  version: number
-  is_offline_sync: boolean
-  created_at: string
-  updated_at: string
-}
+}) as SupabaseClient & SupabaseCallable

--- a/src/lib/supabaseTypes.ts
+++ b/src/lib/supabaseTypes.ts
@@ -1,0 +1,198 @@
+export interface UserProfile {
+  id: string
+  user_id: string
+  full_name?: string
+  email?: string
+  phone?: string
+  role: string
+  date_of_birth?: string
+  sex?: string
+  nationality?: string
+  address?: string
+  city?: string
+  next_of_kin_name?: string
+  next_of_kin_phone?: string
+  avatar_url?: string
+  bio?: string
+  created_at: string
+  updated_at: string
+}
+
+export interface Institution {
+  id: string
+  slug: string
+  name: string
+  full_name: string
+  description?: string
+  logo_url?: string
+  contact_email?: string
+  contact_phone?: string
+  address?: string
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface Program {
+  id: string
+  name: string
+  description?: string
+  duration_years: number
+  department?: string
+  qualification_level?: string
+  entry_requirements?: string
+  fees_per_year?: number
+  institution_id: string
+  is_active: boolean
+  created_by?: string
+  created_at: string
+  updated_at: string
+}
+
+export interface Intake {
+  id: string
+  name: string
+  year: number
+  semester?: string
+  start_date: string
+  end_date: string
+  application_deadline: string
+  total_capacity: number
+  available_spots: number
+  is_active: boolean
+  created_by?: string
+  created_at: string
+  updated_at: string
+}
+
+export interface Application {
+  id: string
+  application_number: string
+  user_id: string
+
+  // Step 1: Basic KYC
+  full_name: string
+  nrc_number?: string
+  passport_number?: string
+  date_of_birth: string
+  sex: 'Male' | 'Female'
+  phone: string
+  email: string
+  residence_town: string
+  next_of_kin_name?: string
+  next_of_kin_phone?: string
+  program: 'Clinical Medicine' | 'Environmental Health' | 'Registered Nursing'
+  intake: string
+  institution: 'KATC' | 'MIHAS'
+
+  // Step 2: Education & Documents
+  result_slip_url?: string
+  extra_kyc_url?: string
+
+  // Step 3: Payment
+  application_fee: number
+  payment_method?: string
+  payer_name?: string
+  payer_phone?: string
+  amount?: number
+  paid_at?: string
+  momo_ref?: string
+  pop_url?: string
+  payment_status: 'pending_review' | 'verified' | 'rejected'
+  payment_verified_at?: string | null
+  payment_verified_by?: string | null
+
+  // Step 4: Status tracking
+  status: 'draft' | 'submitted' | 'under_review' | 'approved' | 'rejected'
+  submitted_at?: string
+
+  // Tracking
+  public_tracking_code?: string
+  created_at: string
+  updated_at: string
+
+  // Admin fields
+  reviewed_by?: string
+  reviewed_at?: string
+  review_started_at?: string
+  review_notes?: string
+  decision_reason?: string
+  decision_date?: string
+}
+
+export interface ApplicationDocument {
+  id: string
+  application_id: string
+  document_type: string
+  document_name: string
+  file_url: string
+  file_size?: number
+  mime_type?: string
+  system_generated: boolean
+  verification_status: 'pending' | 'verified' | 'rejected'
+  verified_by?: string
+  verified_at?: string
+  verification_notes?: string
+  uploaded_at: string
+  created_at: string
+  updated_at: string
+}
+
+export interface ApplicationWithDetails extends Application {
+  programs?: Program
+  intakes?: Intake
+  documents?: ApplicationDocument[]
+}
+
+export interface Grade12Subject {
+  id: string
+  name: string
+  code?: string
+  is_active: boolean
+  created_at: string
+}
+
+export interface ApplicationGrade {
+  id: string
+  application_id: string
+  subject_id: string
+  grade: number
+  created_at: string
+}
+
+export interface UserRole {
+  id: string
+  user_id: string
+  role: string
+  permissions: string[]
+  department?: string
+  assigned_by?: string
+  is_active: boolean
+  assigned_at: string
+  created_at: string
+  updated_at: string
+}
+
+export interface SystemSetting {
+  id: string
+  setting_key: string
+  setting_value?: string
+  setting_type: string
+  description?: string
+  is_public: boolean
+  updated_by?: string
+  created_at: string
+  updated_at: string
+}
+
+export interface ApplicationDraft {
+  id: string
+  user_id: string
+  form_data: Record<string, any>
+  uploaded_files: any[]
+  current_step: number
+  version: number
+  is_offline_sync: boolean
+  created_at: string
+  updated_at: string
+}

--- a/src/pages/student/applicationWizard/__tests__/useApplicationFileUploads.test.tsx
+++ b/src/pages/student/applicationWizard/__tests__/useApplicationFileUploads.test.tsx
@@ -7,13 +7,21 @@ vi.mock('@/lib/storage', () => ({
   uploadApplicationFile: (...args: unknown[]) => uploadApplicationFileMock(...args)
 }))
 
-vi.mock('@/lib/supabase', () => ({
-  supabase: {
+vi.mock('@/lib/supabase', () => {
+  const supabaseClient = {
     auth: {
       getUser: (...args: unknown[]) => getUserMock(...args)
     }
   }
-}))
+
+  const supabaseCallable = vi.fn(async () => supabaseClient)
+  Object.assign(supabaseCallable, supabaseClient)
+
+  return {
+    getSupabaseClient: vi.fn(async () => supabaseClient),
+    supabase: supabaseCallable
+  }
+})
 
 import { render, cleanup } from '@testing-library/react'
 import { act } from 'react'

--- a/src/services/client.ts
+++ b/src/services/client.ts
@@ -76,7 +76,7 @@ class ApiClient {
     }
 
     try {
-      const supabase = getSupabaseClient()
+      const supabase = await getSupabaseClient()
       const { data: { session } } = await supabase.auth.getSession()
       const token = session?.access_token
       if (token) {

--- a/tests/components/ReportsGenerator.test.tsx
+++ b/tests/components/ReportsGenerator.test.tsx
@@ -20,15 +20,23 @@ vi.mock('@/components/ui/Button', () => ({
   )
 }))
 
-vi.mock('@/lib/supabase', () => ({
-  supabase: {
+vi.mock('@/lib/supabase', () => {
+  const supabaseClient = {
     from: vi.fn(() => ({
       select: vi.fn().mockReturnThis(),
       gte: vi.fn().mockReturnThis(),
       lte: vi.fn().mockResolvedValue({ data: [], error: null })
     }))
   }
-}))
+
+  const supabaseCallable = vi.fn(async () => supabaseClient)
+  Object.assign(supabaseCallable, supabaseClient)
+
+  return {
+    getSupabaseClient: vi.fn(async () => supabaseClient),
+    supabase: supabaseCallable
+  }
+})
 
 vi.mock('@/lib/documentTemplates', async () => {
   const actual = await vi.importActual<typeof import('@/lib/documentTemplates')>('@/lib/documentTemplates')

--- a/tests/unit/hooks/useProfileQuery.test.tsx
+++ b/tests/unit/hooks/useProfileQuery.test.tsx
@@ -18,7 +18,7 @@ vi.mock('@/contexts/AuthContext', () => ({
 }))
 
 vi.mock('@/lib/supabase', () => ({
-  getSupabaseClient: () => supabaseClientMock
+  getSupabaseClient: vi.fn(async () => supabaseClientMock)
 }))
 
 function createSupabaseClientMock(options: {

--- a/tests/unit/lazy-loading.test.tsx
+++ b/tests/unit/lazy-loading.test.tsx
@@ -16,13 +16,21 @@ vi.mock('@/contexts/AuthContext', () => ({
 }))
 
 // Mock Supabase
-vi.mock('@/lib/supabase', () => ({
-  supabase: {
+vi.mock('@/lib/supabase', () => {
+  const supabaseClient = {
     auth: {
       getUser: () => Promise.resolve({ data: { user: null }, error: null })
     }
   }
-}))
+
+  const supabaseCallable = vi.fn(async () => supabaseClient)
+  Object.assign(supabaseCallable, supabaseClient)
+
+  return {
+    getSupabaseClient: vi.fn(async () => supabaseClient),
+    supabase: supabaseCallable
+  }
+})
 
 const createTestQueryClient = () => new QueryClient({
   defaultOptions: {

--- a/tests/unit/multiChannelNotifications.test.ts
+++ b/tests/unit/multiChannelNotifications.test.ts
@@ -18,7 +18,15 @@ const { notificationServiceMock, dispatchChannelMock } = vi.hoisted(() => {
   }
 })
 
-vi.mock('@/lib/supabase', () => ({ supabase: supabaseMock }))
+vi.mock('@/lib/supabase', () => {
+  const supabaseCallable = vi.fn(async () => supabaseMock)
+  Object.assign(supabaseCallable, supabaseMock)
+
+  return {
+    getSupabaseClient: vi.fn(async () => supabaseMock),
+    supabase: supabaseCallable
+  }
+})
 
 vi.mock('@/services/notifications', () => ({ notificationService: notificationServiceMock }))
 

--- a/tests/unit/route-config.test.ts
+++ b/tests/unit/route-config.test.ts
@@ -1,28 +1,22 @@
 import { describe, it, expect, vi } from 'vitest'
 
-vi.mock('@/lib/supabase', () => ({
-  createSupabaseClient: vi.fn(() => ({
-    auth: {
-      onAuthStateChange: vi.fn(() => ({
-        data: { subscription: { unsubscribe: vi.fn() } }
-      }))
-    }
-  })),
-  getSupabaseClient: vi.fn(() => ({
-    auth: {
-      onAuthStateChange: vi.fn(() => ({
-        data: { subscription: { unsubscribe: vi.fn() } }
-      }))
-    }
-  })),
-  supabase: {
+vi.mock('@/lib/supabase', () => {
+  const supabaseClient = {
     auth: {
       onAuthStateChange: vi.fn(() => ({
         data: { subscription: { unsubscribe: vi.fn() } }
       }))
     }
   }
-}))
+
+  const supabaseCallable = vi.fn(async () => supabaseClient)
+  Object.assign(supabaseCallable, supabaseClient)
+
+  return {
+    getSupabaseClient: vi.fn(async () => supabaseClient),
+    supabase: supabaseCallable
+  }
+})
 
 import { routes } from '@/routes/config'
 


### PR DESCRIPTION
## Summary
- add a lazy Supabase loader with dynamic import, move database interfaces into supabaseTypes, and expose an async getSupabaseClient/supabase proxy
- update auth listeners, protected routes, analytics utilities, and realtime hooks to await the lazy client before running session checks or network calls
- adjust API client and related tests to work with the async loader and avoid loading Supabase for anonymous scenarios

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdb161b5d88332907bf49d68b7de0a