### PR TITLE
Allow OptimizedImage to accept motion props

### DIFF
--- a/src/components/ui/OptimizedImage.tsx
+++ b/src/components/ui/OptimizedImage.tsx
@@ -1,20 +1,29 @@
 import React, { useState } from 'react'
 import { motion } from 'framer-motion'
 
-interface OptimizedImageProps {
+type MotionImageProps = React.ComponentProps<typeof motion.img>
+
+interface OptimizedImageProps
+  extends Omit<MotionImageProps, 'src' | 'alt' | 'className' | 'onLoad' | 'onError'> {
   src: string
   alt: string
   className?: string
-  loading?: 'lazy' | 'eager'
+  imgClassName?: string
   fallback?: string
+  onLoad?: MotionImageProps['onLoad']
+  onError?: MotionImageProps['onError']
 }
 
 export const OptimizedImage: React.FC<OptimizedImageProps> = ({
   src,
   alt,
   className = '',
+  imgClassName = '',
   loading = 'lazy',
-  fallback = '/images/placeholder.svg'
+  fallback = '/images/placeholder.svg',
+  onLoad,
+  onError,
+  ...motionImageProps
 }) => {
   const [isLoaded, setIsLoaded] = useState(false)
   const [hasError, setHasError] = useState(false)
@@ -26,16 +35,21 @@ export const OptimizedImage: React.FC<OptimizedImageProps> = ({
       )}
       
       <motion.img
+        {...motionImageProps}
         src={hasError ? fallback : src}
         alt={alt}
         loading={loading}
         className={`transition-opacity duration-300 ${
           isLoaded ? 'opacity-100' : 'opacity-0'
-        } max-h-full max-w-full object-contain`}
-        onLoad={() => setIsLoaded(true)}
-        onError={() => {
+        } max-h-full max-w-full object-contain ${imgClassName}`.trim()}
+        onLoad={event => {
+          setIsLoaded(true)
+          onLoad?.(event)
+        }}
+        onError={event => {
           setHasError(true)
           setIsLoaded(true)
+          onError?.(event)
         }}
         initial={{ scale: 0.9 }}
         animate={{ scale: isLoaded ? 1 : 0.9 }}


### PR DESCRIPTION
## Summary
- extend OptimizedImage props from motion.img so callers can pass animation properties again
- keep the loading skeleton and fallback while allowing optional custom class names and handlers

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68cdb35961fc8332b68a75a68e396579