### PR TITLE
Adjust dashboard data load effects

### DIFF
--- a/src/pages/student/Dashboard.tsx
+++ b/src/pages/student/Dashboard.tsx
@@ -42,12 +42,34 @@ export default function StudentDashboard() {
   const [hasDraft, setHasDraft] = useState(false)
   const [draftData, setDraftData] = useState<any>(null)
   const hasLoadedRef = useRef(false)
+  const previousUserIdRef = useRef<string | null>(null)
 
   useEffect(() => {
-    if (user) {
+    const currentUserId = user?.id ?? null
+
+    if (!currentUserId) {
+      previousUserIdRef.current = null
+      hasLoadedRef.current = false
+      return
+    }
+
+    const userChanged = previousUserIdRef.current !== currentUserId
+
+    if (userChanged || !hasLoadedRef.current) {
+      if (userChanged) {
+        hasLoadedRef.current = false
+      }
+
+      previousUserIdRef.current = currentUserId
       loadDashboardData()
     }
-  }, [user, profile])
+  }, [user?.id])
+
+  useEffect(() => {
+    if (profile && hasLoadedRef.current) {
+      loadDashboardData()
+    }
+  }, [profile])
 
   // Listen for storage changes to update draft status
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure the student dashboard loads data only when the authenticated user changes by tracking the previous user id and guarding the initial effect
- trigger profile-driven refreshes only after the first load completes so that the refresh path uses the lightweight state updates

## Testing
- npm run lint *(fails: existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb6f0514c8332af45fd2954a8c5f2