### PR TITLE
Optimize report exports for vercel build

### DIFF
--- a/src/lib/reportExports.ts
+++ b/src/lib/reportExports.ts
@@ -1,7 +1,3 @@
-import jsPDF from 'jspdf'
-import autoTable from 'jspdf-autotable'
-import ExcelJS from 'exceljs'
-
 export type ReportFormat = 'json' | 'pdf' | 'excel'
 
 export interface ProgramBreakdownStats {
@@ -49,7 +45,11 @@ export const exportReportAsJson = (reportData: ReportExportData, fileName: strin
   triggerDownload(blob, `${sanitizeFileName(fileName)}.json`)
 }
 
-export const exportReportAsPdf = (reportData: ReportExportData, fileName: string) => {
+export const exportReportAsPdf = async (reportData: ReportExportData, fileName: string) => {
+  const [{ default: jsPDF }, { default: autoTable }] = await Promise.all([
+    import('jspdf'),
+    import('jspdf-autotable')
+  ])
   const doc = new jsPDF()
   const marginLeft = 14
   let currentY = 20
@@ -125,6 +125,7 @@ export const exportReportAsPdf = (reportData: ReportExportData, fileName: string
 }
 
 export const exportReportAsExcel = async (reportData: ReportExportData, fileName: string) => {
+  const { default: ExcelJS } = await import('exceljs')
   const workbook = new ExcelJS.Workbook()
   workbook.created = new Date()
   workbook.modified = new Date()
@@ -227,7 +228,7 @@ export const exportReport = async (
   fileName: string
 ) => {
   if (format === 'pdf') {
-    exportReportAsPdf(reportData, fileName)
+    await exportReportAsPdf(reportData, fileName)
     return
   }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -125,8 +125,20 @@ export default defineConfig(({ mode }) => {
         output: {
           manualChunks: (id) => {
             if (id.includes('node_modules')) {
-              if (id.includes('react') || id.includes('react-dom')) {
-                return 'vendor'
+              if (id.includes('node_modules/react/') || id.includes('node_modules/react-dom')) {
+                return 'react'
+              }
+              if (id.includes('@tanstack/react-query')) {
+                return 'react-query'
+              }
+              if (id.includes('react-router-dom')) {
+                return 'router'
+              }
+              if (id.includes('react-hook-form')) {
+                return 'forms'
+              }
+              if (id.includes('zustand')) {
+                return 'state'
               }
               if (id.includes('@supabase')) {
                 return 'supabase'
@@ -136,6 +148,24 @@ export default defineConfig(({ mode }) => {
               }
               if (id.includes('@radix-ui')) {
                 return 'ui'
+              }
+              if (id.includes('jspdf') || id.includes('jspdf-autotable') || id.includes('pdf-lib')) {
+                return 'reporting'
+              }
+              if (id.includes('exceljs')) {
+                return 'exceljs'
+              }
+              if (id.includes('/xlsx')) {
+                return 'xlsx'
+              }
+              if (id.includes('date-fns')) {
+                return 'date-utils'
+              }
+              if (id.includes('lucide-react')) {
+                return 'icons'
+              }
+              if (id.includes('dompurify')) {
+                return 'sanitizers'
               }
               return 'vendor'
             }


### PR DESCRIPTION
## Summary
- lazy-load heavy reporting dependencies so the Vercel build only downloads PDF/Excel tooling when exports run
- tune manual chunking in the Vite config to split major third-party libraries into dedicated bundles and eliminate large chunk warnings during production builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cde5b57ec08332a2ed16290aab6266