### PR TITLE
Use type-only Supabase imports in application schema

### DIFF
--- a/src/forms/applicationSchema.ts
+++ b/src/forms/applicationSchema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { Program, Intake } from '@/lib/supabase'
+import type { Program, Intake } from '@/lib/supabaseTypes'
 
 export const DEFAULT_PROGRAMS: Program[] = [
   {


### PR DESCRIPTION
## Summary
- switch the application form schema to import Program and Intake from supabaseTypes using a type-only import
- avoid touching the runtime Supabase client when loading the form schema

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68cdef5b45d48332aa08cc19de19abb9