### PR TITLE
Refactor admin routes into dedicated dashboard and audit handlers

### DIFF
--- a/api/admin/audit-log.js
+++ b/api/admin/audit-log.js
@@ -1,0 +1,136 @@
+const { logAuditEvent } = require('../_lib/auditLogger')
+const { supabaseAdminClient, getUserFromRequest } = require('../_lib/supabaseClient')
+
+function parseAction(value) {
+  if (Array.isArray(value)) {
+    return value[0] ?? null
+  }
+  if (typeof value === 'string') {
+    return value
+  }
+  return null
+}
+
+function normalizeRecord(record) {
+  if (!record) {
+    return null
+  }
+
+  return {
+    id: record.id,
+    action: record.action,
+    actorId: record.actor_id,
+    actorEmail: record.actor_email,
+    actorRoles: record.actor_roles || [],
+    targetTable: record.target_table,
+    targetId: record.target_id,
+    targetLabel: record.target_label,
+    requestId: record.request_id,
+    requestIp: record.request_ip,
+    userAgent: record.user_agent,
+    metadata: record.metadata || {},
+    createdAt: record.created_at
+  }
+}
+
+module.exports = async function handler(req, res) {
+  const authContext = await getUserFromRequest(req, { requireAdmin: true })
+  if (authContext.error) {
+    const status = authContext.error === 'Access denied' ? 403 : 401
+    return res.status(status).json({ error: authContext.error })
+  }
+
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET')
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const {
+    actorId,
+    targetTable,
+    targetId,
+    from,
+    to,
+    page = '1',
+    pageSize = '25',
+    logAction,
+    eventAction,
+    auditAction
+  } = req.query || {}
+
+  const normalizedPage = Number.parseInt(Array.isArray(page) ? page[0] : page, 10)
+  const normalizedPageSize = Number.parseInt(Array.isArray(pageSize) ? pageSize[0] : pageSize, 10)
+
+  const limit = Number.isNaN(normalizedPageSize) ? 25 : Math.min(Math.max(normalizedPageSize, 5), 100)
+  const currentPage = Number.isNaN(normalizedPage) ? 1 : Math.max(normalizedPage, 1)
+  const offset = (currentPage - 1) * limit
+
+  let query = supabaseAdminClient
+    .from('system_audit_log')
+    .select('*', { count: 'exact' })
+    .order('created_at', { ascending: false })
+    .range(offset, offset + limit - 1)
+
+  const auditActionFilter = parseAction(logAction) || parseAction(eventAction) || parseAction(auditAction)
+  if (auditActionFilter) {
+    query = query.ilike('action', `${auditActionFilter}%`)
+  }
+  if (actorId) {
+    query = query.eq('actor_id', Array.isArray(actorId) ? actorId[0] : actorId)
+  }
+  if (targetTable) {
+    query = query.eq('target_table', Array.isArray(targetTable) ? targetTable[0] : targetTable)
+  }
+  if (targetId) {
+    query = query.eq('target_id', Array.isArray(targetId) ? targetId[0] : targetId)
+  }
+  if (from) {
+    const parsed = new Date(Array.isArray(from) ? from[0] : from)
+    if (!Number.isNaN(parsed.getTime())) {
+      query = query.gte('created_at', parsed.toISOString())
+    }
+  }
+  if (to) {
+    const parsed = new Date(Array.isArray(to) ? to[0] : to)
+    if (!Number.isNaN(parsed.getTime())) {
+      query = query.lte('created_at', parsed.toISOString())
+    }
+  }
+
+  const { data, count, error } = await query
+  if (error) {
+    console.error('Audit log query failed', error)
+    return res.status(500).json({ error: 'Failed to load audit log entries' })
+  }
+
+  const records = (data || []).map(normalizeRecord)
+  const totalCount = typeof count === 'number' ? count : records.length
+  const totalPages = limit > 0 ? Math.max(Math.ceil(totalCount / limit), 1) : 1
+
+  await logAuditEvent({
+    req,
+    action: 'audit.log.view',
+    actorId: authContext.user.id,
+    actorEmail: authContext.user.email || null,
+    actorRoles: authContext.roles,
+    targetTable: 'system_audit_log',
+    metadata: {
+      filters: {
+        action: auditActionFilter || null,
+        actorId: actorId ? (Array.isArray(actorId) ? actorId[0] : actorId) : null,
+        targetTable: targetTable ? (Array.isArray(targetTable) ? targetTable[0] : targetTable) : null,
+        targetId: targetId ? (Array.isArray(targetId) ? targetId[0] : targetId) : null
+      },
+      page: currentPage,
+      pageSize: limit
+    }
+  })
+
+  return res.status(200).json({
+    data: records,
+    page: currentPage,
+    pageSize: limit,
+    totalPages,
+    totalCount
+  })
+}

--- a/api/admin/dashboard.js
+++ b/api/admin/dashboard.js
@@ -7,39 +7,13 @@ const {
 const { logAuditEvent } = require('../_lib/auditLogger')
 const { supabaseAdminClient, getUserFromRequest } = require('../_lib/supabaseClient')
 
-function parseAction(value) {
-  if (Array.isArray(value)) {
-    return value[0] ?? null
-  }
-  if (typeof value === 'string') {
-    return value
-  }
-  return null
-}
-
-function normalizeRecord(record) {
-  if (!record) {
-    return null
+module.exports = async function handler(req, res) {
+  const authContext = await getUserFromRequest(req, { requireAdmin: true })
+  if (authContext.error) {
+    const status = authContext.error === 'Access denied' ? 403 : 401
+    return res.status(status).json({ error: authContext.error })
   }
 
-  return {
-    id: record.id,
-    action: record.action,
-    actorId: record.actor_id,
-    actorEmail: record.actor_email,
-    actorRoles: record.actor_roles || [],
-    targetTable: record.target_table,
-    targetId: record.target_id,
-    targetLabel: record.target_label,
-    requestId: record.request_id,
-    requestIp: record.request_ip,
-    userAgent: record.user_agent,
-    metadata: record.metadata || {},
-    createdAt: record.created_at
-  }
-}
-
-async function handleDashboard(req, res, authContext) {
   if (req.method !== 'GET') {
     res.setHeader('Allow', 'GET')
     return res.status(405).json({ error: 'Method not allowed' })
@@ -170,120 +144,4 @@ async function handleDashboard(req, res, authContext) {
     console.error('Dashboard API error:', error)
     return res.status(500).json({ error: 'Failed to load admin dashboard overview' })
   }
-}
-
-async function handleAuditLog(req, res, authContext) {
-  if (req.method !== 'GET') {
-    res.setHeader('Allow', 'GET')
-    return res.status(405).json({ error: 'Method not allowed' })
-  }
-
-  const {
-    actorId,
-    targetTable,
-    targetId,
-    from,
-    to,
-    page = '1',
-    pageSize = '25',
-    logAction,
-    eventAction,
-    auditAction
-  } = req.query || {}
-
-  const normalizedPage = Number.parseInt(Array.isArray(page) ? page[0] : page, 10)
-  const normalizedPageSize = Number.parseInt(Array.isArray(pageSize) ? pageSize[0] : pageSize, 10)
-
-  const limit = Number.isNaN(normalizedPageSize) ? 25 : Math.min(Math.max(normalizedPageSize, 5), 100)
-  const currentPage = Number.isNaN(normalizedPage) ? 1 : Math.max(normalizedPage, 1)
-  const offset = (currentPage - 1) * limit
-
-  let query = supabaseAdminClient
-    .from('system_audit_log')
-    .select('*', { count: 'exact' })
-    .order('created_at', { ascending: false })
-    .range(offset, offset + limit - 1)
-
-  const auditActionFilter = parseAction(logAction) || parseAction(eventAction) || parseAction(auditAction)
-  if (auditActionFilter) {
-    query = query.ilike('action', `${auditActionFilter}%`)
-  }
-  if (actorId) {
-    query = query.eq('actor_id', Array.isArray(actorId) ? actorId[0] : actorId)
-  }
-  if (targetTable) {
-    query = query.eq('target_table', Array.isArray(targetTable) ? targetTable[0] : targetTable)
-  }
-  if (targetId) {
-    query = query.eq('target_id', Array.isArray(targetId) ? targetId[0] : targetId)
-  }
-  if (from) {
-    const parsed = new Date(Array.isArray(from) ? from[0] : from)
-    if (!Number.isNaN(parsed.getTime())) {
-      query = query.gte('created_at', parsed.toISOString())
-    }
-  }
-  if (to) {
-    const parsed = new Date(Array.isArray(to) ? to[0] : to)
-    if (!Number.isNaN(parsed.getTime())) {
-      query = query.lte('created_at', parsed.toISOString())
-    }
-  }
-
-  const { data, count, error } = await query
-  if (error) {
-    console.error('Audit log query failed', error)
-    return res.status(500).json({ error: 'Failed to load audit log entries' })
-  }
-
-  const records = (data || []).map(normalizeRecord)
-  const totalCount = typeof count === 'number' ? count : records.length
-  const totalPages = limit > 0 ? Math.max(Math.ceil(totalCount / limit), 1) : 1
-
-  await logAuditEvent({
-    req,
-    action: 'audit.log.view',
-    actorId: authContext.user.id,
-    actorEmail: authContext.user.email || null,
-    actorRoles: authContext.roles,
-    targetTable: 'system_audit_log',
-    metadata: {
-      filters: {
-        action: auditActionFilter || null,
-        actorId: actorId ? (Array.isArray(actorId) ? actorId[0] : actorId) : null,
-        targetTable: targetTable ? (Array.isArray(targetTable) ? targetTable[0] : targetTable) : null,
-        targetId: targetId ? (Array.isArray(targetId) ? targetId[0] : targetId) : null
-      },
-      page: currentPage,
-      pageSize: limit
-    }
-  })
-
-  return res.status(200).json({
-    data: records,
-    page: currentPage,
-    pageSize: limit,
-    totalPages,
-    totalCount
-  })
-}
-
-module.exports = async function handler(req, res) {
-  const authContext = await getUserFromRequest(req, { requireAdmin: true })
-  if (authContext.error) {
-    const status = authContext.error === 'Access denied' ? 403 : 401
-    return res.status(status).json({ error: authContext.error })
-  }
-
-  const action = parseAction(req.query?.action) || 'dashboard'
-
-  if (action === 'dashboard') {
-    return handleDashboard(req, res, authContext)
-  }
-
-  if (action === 'audit-log') {
-    return handleAuditLog(req, res, authContext)
-  }
-
-  return res.status(400).json({ error: 'Invalid admin action' })
 }

--- a/debug-admin-access.html
+++ b/debug-admin-access.html
@@ -88,7 +88,7 @@
             log('🔍 Testing API access...', 'info')
             
             try {
-                const response = await fetch('/api/admin?action=dashboard', {
+                const response = await fetch('/api/admin/dashboard', {
                     headers: {
                         'Authorization': `Bearer ${currentSession.access_token}`,
                         'Content-Type': 'application/json'

--- a/debug-admin-access.js
+++ b/debug-admin-access.js
@@ -72,7 +72,7 @@ async function debugAdminAccess() {
     // Test API access
     console.log('\n🌐 Testing API Access...')
     try {
-      const response = await fetch('/api/admin?action=dashboard', {
+      const response = await fetch('/api/admin/dashboard', {
         headers: {
           'Authorization': `Bearer ${session.access_token}`,
           'Content-Type': 'application/json'

--- a/src/services/admin/audit.ts
+++ b/src/services/admin/audit.ts
@@ -54,7 +54,7 @@ function buildQuery(params: AuditLogFilters = {}): string {
 export const adminAuditService = {
   async list(params: AuditLogFilters = {}): Promise<AuditLogResponse> {
     const query = buildQuery(params)
-    const url = `/api/admin?action=audit-log${query ? `&${query.slice(1)}` : ''}`
+    const url = `/api/admin/audit-log${query}`
     return apiClient.request(url, {
       method: 'GET'
     })

--- a/src/services/admin/dashboard.ts
+++ b/src/services/admin/dashboard.ts
@@ -309,7 +309,7 @@ export const createEmptyDashboardResponse = (): AdminDashboardResponse => ({
 
 export const adminDashboardService = {
   async getOverview(): Promise<AdminDashboardResponse> {
-    const response = await apiClient.request('/api/admin?action=dashboard')
+    const response = await apiClient.request('/api/admin/dashboard')
 
     if (!response || typeof response !== 'object') {
       return createEmptyDashboardResponse()

--- a/test-admin-login-correct.js
+++ b/test-admin-login-correct.js
@@ -36,7 +36,7 @@ async function testAdminLogin() {
     
     // Test API access
     console.log('\n🔍 Testing API access...')
-    const response = await fetch('http://localhost:5173/api/admin?action=dashboard', {
+    const response = await fetch('http://localhost:5173/api/admin/dashboard', {
       headers: {
         'Authorization': `Bearer ${data.session.access_token}`,
         'Content-Type': 'application/json'

--- a/test-admin-login-fixed.js
+++ b/test-admin-login-fixed.js
@@ -42,7 +42,7 @@ async function testAdminLogin() {
       
       // Test API access
       console.log('\n🔍 Testing API access...')
-      const response = await fetch('http://localhost:5173/api/admin?action=dashboard', {
+      const response = await fetch('http://localhost:5173/api/admin/dashboard', {
         headers: {
           'Authorization': `Bearer ${data.session.access_token}`,
           'Content-Type': 'application/json'

--- a/test-admin-login.js
+++ b/test-admin-login.js
@@ -64,7 +64,7 @@ async function testAdminLogin() {
     
     // Test API access
     console.log('\n🔍 Testing API access...')
-    const response = await fetch('http://localhost:5173/api/admin?action=dashboard', {
+    const response = await fetch('http://localhost:5173/api/admin/dashboard', {
       headers: {
         'Authorization': `Bearer ${data.session.access_token}`,
         'Content-Type': 'application/json'

--- a/test-api-services.js
+++ b/test-api-services.js
@@ -46,7 +46,7 @@ async function runTests() {
   
   // Test Admin Dashboard API
   console.log('\n📊 Testing Admin Dashboard API:')
-  await testEndpoint('/api/admin?action=dashboard', 'GET')
+  await testEndpoint('/api/admin/dashboard', 'GET')
 
   console.log('\n✨ API Service tests completed!')
   console.log('\n📝 Note: Admin endpoints require valid authentication tokens')

--- a/tests/unit/api/admin-dashboard.test.ts
+++ b/tests/unit/api/admin-dashboard.test.ts
@@ -13,7 +13,7 @@ const getUserFromRequestMock = vi.fn()
 const nodeRequire = createRequire(import.meta.url)
 const supabaseModulePath = nodeRequire.resolve('../../../api/_lib/supabaseClient.js')
 const auditLoggerModulePath = nodeRequire.resolve('../../../api/_lib/auditLogger.js')
-const handlerModulePath = nodeRequire.resolve('../../../api/admin/index.js')
+const handlerModulePath = nodeRequire.resolve('../../../api/admin/dashboard.js')
 
 type StatusMock = MockInstance<[number], TestResponse>
 type JsonMock = MockInstance<[unknown], TestResponse>
@@ -89,7 +89,7 @@ function createMockResponse(): TestResponse {
   return response
 }
 
-describe('api/admin?action=dashboard', () => {
+describe('api/admin/dashboard', () => {
   beforeEach(async () => {
     mockSupabaseModule()
     fromMock.mockReset()
@@ -119,7 +119,7 @@ describe('api/admin?action=dashboard', () => {
       delete: vi.fn(() => deleteBuilder)
     })
 
-    const module = await import('../../../api/admin/index.js')
+    const module = await import('../../../api/admin/dashboard.js')
     handler = (module.default || module) as Handler
   })
 
@@ -172,17 +172,15 @@ describe('api/admin?action=dashboard', () => {
     }
 
     getUserFromRequestMock.mockResolvedValue({ user: { id: 'admin' }, roles: ['admin'], isAdmin: true })
-    maybeSingleMock
-      .mockResolvedValueOnce({ data: null, error: null })
-      .mockResolvedValueOnce({
-        data: { metrics: overview, generated_at: '2025-02-21T10:00:00Z' },
-        error: null
-      })
+    maybeSingleMock.mockResolvedValueOnce({
+      data: { metrics: overview, generated_at: '2025-02-21T10:00:00Z' },
+      error: null
+    })
 
     const req = {
       method: 'GET',
       headers: { authorization: 'Bearer token' },
-      query: { action: 'dashboard' }
+      query: {}
     }
     const res = createMockResponse()
 
@@ -228,14 +226,12 @@ describe('api/admin?action=dashboard', () => {
 
   it('returns an error response when the cache lookup fails', async () => {
     getUserFromRequestMock.mockResolvedValue({ user: { id: 'admin' }, roles: ['admin'], isAdmin: true })
-    maybeSingleMock
-      .mockResolvedValueOnce({ data: null, error: null })
-      .mockResolvedValueOnce({ data: null, error: { message: 'cache failure' } })
+    maybeSingleMock.mockResolvedValueOnce({ data: null, error: { message: 'cache failure' } })
 
     const req = {
       method: 'GET',
       headers: { authorization: 'Bearer token' },
-      query: { action: 'dashboard' }
+      query: {}
     }
     const res = createMockResponse()
 

--- a/verify-api-consolidation.js
+++ b/verify-api-consolidation.js
@@ -51,19 +51,32 @@ consolidatedAPIs.forEach(api => {
 
 // 3. Check consolidated admin APIs
 console.log('\n🛡️ Checking Admin APIs:');
-const adminIndexPath = path.join('api', 'admin', 'index.js');
-if (fs.existsSync(adminIndexPath)) {
-  const adminIndexContent = fs.readFileSync(adminIndexPath, 'utf8');
-  const hasDashboard = /action === 'dashboard'/.test(adminIndexContent) && adminIndexContent.includes('generatedAt');
-  const hasAuditLog = /action === 'audit-log'/.test(adminIndexContent) && adminIndexContent.includes('normalizeRecord');
+const adminDashboardPath = path.join('api', 'admin', 'dashboard.js');
+if (fs.existsSync(adminDashboardPath)) {
+  const adminDashboardContent = fs.readFileSync(adminDashboardPath, 'utf8');
+  const hasDashboardLogic = adminDashboardContent.includes('admin_dashboard_metrics_cache') && adminDashboardContent.includes('logAuditEvent');
 
-  if (hasDashboard && hasAuditLog) {
-    console.log('✅ api/admin/index.js - Handles dashboard and audit-log actions');
+  if (hasDashboardLogic) {
+    console.log('✅ api/admin/dashboard.js - Dedicated dashboard handler present');
   } else {
-    console.log('❌ api/admin/index.js - Missing dashboard or audit-log handler');
+    console.log('❌ api/admin/dashboard.js - Missing dashboard metrics handler');
   }
 } else {
-  console.log('❌ api/admin/index.js - File not found');
+  console.log('❌ api/admin/dashboard.js - File not found');
+}
+
+const adminAuditPath = path.join('api', 'admin', 'audit-log.js');
+if (fs.existsSync(adminAuditPath)) {
+  const adminAuditContent = fs.readFileSync(adminAuditPath, 'utf8');
+  const hasAuditLogic = adminAuditContent.includes('system_audit_log') && adminAuditContent.includes('normalizeRecord');
+
+  if (hasAuditLogic) {
+    console.log('✅ api/admin/audit-log.js - Dedicated audit log handler present');
+  } else {
+    console.log('❌ api/admin/audit-log.js - Missing audit log handler');
+  }
+} else {
+  console.log('❌ api/admin/audit-log.js - File not found');
 }
 
 const adminUsersPath = path.join('api', 'admin', 'users.js');
@@ -94,8 +107,8 @@ if (fs.existsSync(edgeFunctionPath)) {
 // 4. Check frontend integration
 console.log('\n🎨 Checking Frontend Integration:');
 const frontendChecks = [
-  { name: 'Admin dashboard service', file: 'src/services/admin/dashboard.ts', pattern: /\/api\/admin\?action=dashboard/ },
-  { name: 'Admin audit service', file: 'src/services/admin/audit.ts', pattern: /\/api\/admin\?action=audit-log/ },
+  { name: 'Admin dashboard service', file: 'src/services/admin/dashboard.ts', pattern: /\/api\/admin\/dashboard/ },
+  { name: 'Admin audit service', file: 'src/services/admin/audit.ts', pattern: /\/api\/admin\/audit-log/ },
   { name: 'Admin users service', file: 'src/services/admin/users.ts', pattern: /\/api\/admin\/users\?id=/ }
 ];
 


### PR DESCRIPTION
## Summary
- split the combined admin API into dedicated `/api/admin/dashboard` and `/api/admin/audit-log` handlers while preserving rate limiting, logging, and normalization
- update admin services, debug helpers, and tests to target the new routes directly
- remove the obsolete action-switching entry point after migrating consumers

## Testing
- npx vitest tests/unit/api/admin-dashboard.test.ts --run

------
https://chatgpt.com/codex/tasks/task_e_68ce6d45cec08332a846674b8ffefbf2