### PR TITLE
Handle missing Supabase configuration gracefully

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -2,7 +2,8 @@ import React, { useEffect, useState } from 'react'
 import { Navigate } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
-import { supabase } from '@/lib/supabase'
+import { supabase, isSupabaseConfigured } from '@/lib/supabase'
+import { SupabaseConfigError } from '@/components/SupabaseConfigError'
 
 interface ProtectedRouteProps {
   children: React.ReactNode
@@ -11,6 +12,7 @@ interface ProtectedRouteProps {
 export function ProtectedRoute({ children }: ProtectedRouteProps) {
   const { user, loading } = useAuth()
   const [sessionChecked, setSessionChecked] = useState(false)
+  const supabaseAvailable = isSupabaseConfigured
 
   useEffect(() => {
     // Double-check session on mount
@@ -26,11 +28,20 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
         setSessionChecked(true)
       }
     }
-    
+
+    if (!supabaseAvailable) {
+      setSessionChecked(true)
+      return
+    }
+
     if (!loading) {
       checkSession()
     }
-  }, [loading])
+  }, [loading, supabaseAvailable])
+
+  if (!supabaseAvailable) {
+    return <SupabaseConfigError />
+  }
 
   if (loading || !sessionChecked) {
     return (

--- a/src/components/SupabaseConfigError.tsx
+++ b/src/components/SupabaseConfigError.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { SUPABASE_CONFIG_ERROR_MESSAGE } from '@/lib/supabase'
+
+export function SupabaseConfigError() {
+  return (
+    <div
+      className="min-h-screen flex items-center justify-center bg-gray-50 p-6"
+      data-testid="supabase-config-error"
+    >
+      <div className="max-w-md text-center space-y-4">
+        <h1 className="text-2xl font-semibold text-gray-900">Configuration required</h1>
+        <p className="text-gray-700">{SUPABASE_CONFIG_ERROR_MESSAGE}</p>
+        <p className="text-sm text-gray-500">
+          Update the <code>VITE_SUPABASE_URL</code> and <code>VITE_SUPABASE_ANON_KEY</code> environment variables to{' '}
+          enable Supabase-backed authentication and analytics features.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/tests/app.supabase-config.test.tsx
+++ b/tests/app.supabase-config.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+describe('App Supabase configuration handling', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllEnvs()
+    vi.stubEnv('VITE_SUPABASE_URL', '')
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', '')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('renders a helpful configuration message when Supabase env vars are missing', async () => {
+    const { default: App } = await import('@/App')
+
+    render(<App />)
+
+    expect(screen.getByTestId('supabase-config-error')).toBeTruthy()
+    expect(screen.getByText(/Supabase client is not configured/i)).toBeTruthy()
+  })
+})

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -10,7 +10,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    include: ['tests/**/*.test.{js,ts}'],
+    include: ['tests/**/*.test.{js,ts,tsx}'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary
- add a Supabase configuration guard so the client is only created when environment variables are present
- render a friendly configuration error and skip auth/analytics flows when Supabase is unavailable
- cover the behaviour with a Vitest regression test that mounts the app without the env vars

## Testing
- npm run test:unit -- --run tests/app.supabase-config.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cec65b8eb883329b8e7143613ef392