### PR TITLE
Eager load landing page hero content

### DIFF
--- a/src/pages/LandingPageOptimized.tsx
+++ b/src/pages/LandingPageOptimized.tsx
@@ -1,13 +1,5 @@
-import React, { lazy, Suspense } from 'react'
-import { LandingPageSkeleton } from '@/components/ui/LandingPageSkeleton'
-
-// Lazy load the full landing page
-const LandingPageFull = lazy(() => import('./LandingPage'))
+import LandingPage from './LandingPage'
 
 export default function LandingPageOptimized() {
-  return (
-    <Suspense fallback={<LandingPageSkeleton />}>
-      <LandingPageFull />
-    </Suspense>
-  )
+  return <LandingPage />
 }

--- a/src/routes/config.tsx
+++ b/src/routes/config.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 // Import critical pages directly for faster loading
-import LandingPageOptimized from '@/pages/LandingPageOptimized'
+import LandingPage from '@/pages/LandingPage'
 import SignInPage from '@/pages/auth/SignInPage'
 import SignUpPage from '@/pages/auth/SignUpPage'
 
@@ -42,7 +42,7 @@ export interface RouteConfig {
 
 export const routes: RouteConfig[] = [
   // Public routes
-  { path: '/', element: LandingPageOptimized, guard: 'public' },
+  { path: '/', element: LandingPage, guard: 'public' },
   { path: '/track-application', element: PublicApplicationTracker, guard: 'public', lazy: true },
   { path: '/auth/signin', element: SignInPage, guard: 'public' },
   { path: '/signin', element: SignInPage, guard: 'public' },


### PR DESCRIPTION
## Summary
- replace the LandingPageOptimized wrapper with an eager render of the main landing page so the hero ships in the entry chunk
- update the root route to import the eagerly rendered landing page component

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cecc1a5b548332a55ba63b88febba7