### PR TITLE
Make applications table container responsive

### DIFF
--- a/src/components/admin/applications/ApplicationsTable.tsx
+++ b/src/components/admin/applications/ApplicationsTable.tsx
@@ -103,7 +103,7 @@ export function ApplicationsTable({
   return (
     <div className="bg-white rounded-lg shadow overflow-hidden">
       <div className="overflow-x-auto">
-        <div className="min-w-[1024px]">
+        <div className="w-full md:min-w-[1024px]">
           <div className="hidden bg-gray-50 px-6 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500 md:grid md:grid-cols-[minmax(160px,1fr)_minmax(220px,1.4fr)_minmax(200px,1.2fr)_minmax(170px,1fr)_minmax(220px,1.3fr)_minmax(200px,1fr)_minmax(160px,0.8fr)]">
             <div>Application</div>
             <div>Student</div>


### PR DESCRIPTION
## Summary
- make the admin applications table wrapper full width by default and only enforce the 1024px minimum on medium viewports

## Testing
- npm run lint *(fails: existing lint violations unrelated to this change)*
- Manual QA: Verified /admin/applications on 375px wide viewport that no horizontal scrolling is required and all action controls remain visible

------
https://chatgpt.com/codex/tasks/task_e_68d02f890fa88332a199083c3829ee78