### PR TITLE
Add Netlify wrapper for notifications dispatch channel

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -17,6 +17,7 @@
 /api/mcp/query /.netlify/functions/mcp-query 200
 /api/mcp/schema /.netlify/functions/mcp-schema 200
 /api/notifications/send /.netlify/functions/notifications-send 200
+/api/notifications/dispatch-channel /.netlify/functions/notifications-dispatch-channel 200
 /api/notifications/application-submitted /.netlify/functions/notifications-application-submitted 200
 /api/notifications/preferences /.netlify/functions/notifications-preferences 200
 /api/notifications/update-consent /.netlify/functions/notifications-update-consent 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -24,6 +24,12 @@
   force = true
 
 [[redirects]]
+  from = "/api/notifications/dispatch-channel"
+  to = "/.netlify/functions/notifications-dispatch-channel"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/api/*"
   to = "/.netlify/functions/:splat"
   status = 200

--- a/netlify/functions/notifications-dispatch-channel.js
+++ b/netlify/functions/notifications-dispatch-channel.js
@@ -1,0 +1,55 @@
+const handler = require('../../api/notifications/dispatch-channel.js')
+
+exports.handler = async (event, context) => {
+  const req = {
+    method: event.httpMethod,
+    query: event.queryStringParameters || {},
+    body: event.body,
+    headers: event.headers,
+    params: event.pathParameters || {}
+  }
+
+  const res = {
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization'
+    },
+    setHeader: function(name, value) { this.headers[name] = value },
+    status: function(code) { this.statusCode = code; return this },
+    json: function(data) { this.body = JSON.stringify(data); return this },
+    end: function(data) { this.body = data || ''; return this }
+  }
+
+  // Handle OPTIONS preflight
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 200,
+      headers: res.headers,
+      body: ''
+    }
+  }
+
+  try {
+    if (typeof handler === 'function') {
+      await handler(req, res)
+    } else if (handler.handler) {
+      await handler.handler(req, res)
+    } else if (handler.default) {
+      await handler.default(req, res)
+    } else {
+      await handler(req, res)
+    }
+  } catch (error) {
+    console.error('notifications-dispatch-channel error:', error)
+    res.status(500).json({ error: 'Internal server error' })
+  }
+
+  return {
+    statusCode: res.statusCode,
+    headers: res.headers,
+    body: res.body || JSON.stringify({ error: 'No response' })
+  }
+}

--- a/scripts/generate-netlify-functions.js
+++ b/scripts/generate-netlify-functions.js
@@ -66,6 +66,7 @@ const endpoints = [
   { path: 'catalog/subjects.js', name: 'catalog-subjects' },
   { path: 'documents/upload.js', name: 'documents-upload' },
   { path: 'notifications/send.js', name: 'notifications-send' },
+  { path: 'notifications/dispatch-channel.js', name: 'notifications-dispatch-channel' },
   { path: 'notifications/application-submitted.js', name: 'notifications-application-submitted' },
   { path: 'notifications/preferences.js', name: 'notifications-preferences' },
   { path: 'notifications/update-consent.js', name: 'notifications-update-consent' },


### PR DESCRIPTION
## Summary
- add a Netlify wrapper for the notifications dispatch channel endpoint
- map the /api/notifications/dispatch-channel route to the new function in both redirect configs
- update the Netlify function generator script so the dispatch-channel wrapper is maintained

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0674ce8588332912b54d953a659ec