### PR TITLE
Add Netlify proxies for admin user role/permissions endpoints

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -2,6 +2,8 @@
 /api/admin/dashboard /.netlify/functions/admin-dashboard 200
 /api/admin/users /.netlify/functions/admin-users 200
 /api/admin/users/:id /.netlify/functions/admin-users-id 200
+/api/admin/users/:id/role /.netlify/functions/admin-users-role?id=:id 200
+/api/admin/users/:id/permissions /.netlify/functions/admin-users-permissions?id=:id 200
 /api/analytics/metrics /.netlify/functions/analytics-metrics 200
 /api/analytics/telemetry /.netlify/functions/analytics-telemetry 200
 /api/analytics/predictive-dashboard /.netlify/functions/analytics-predictive-dashboard 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,6 +12,18 @@
   force = true
 
 [[redirects]]
+  from = "/api/admin/users/:id/role"
+  to = "/.netlify/functions/admin-users-role?id=:id"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/api/admin/users/:id/permissions"
+  to = "/.netlify/functions/admin-users-permissions?id=:id"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/api/analytics/telemetry"
   to = "/.netlify/functions/analytics-telemetry"
   status = 200

--- a/netlify/functions/admin-users-permissions.js
+++ b/netlify/functions/admin-users-permissions.js
@@ -1,0 +1,77 @@
+const handler = require('../../api/admin/users/[id]/permissions.js')
+
+exports.handler = async (event) => {
+  const pathParameters = event.pathParameters || {}
+  const query = { ...(event.queryStringParameters || {}) }
+
+  if (pathParameters.id && !query.id) {
+    query.id = pathParameters.id
+  }
+
+  const params = { ...pathParameters }
+  if (!params.id && query.id) {
+    params.id = query.id
+  }
+
+  const req = {
+    method: event.httpMethod,
+    query,
+    body: event.body,
+    headers: event.headers,
+    params
+  }
+
+  const res = {
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization'
+    },
+    setHeader(name, value) {
+      this.headers[name] = value
+    },
+    status(code) {
+      this.statusCode = code
+      return this
+    },
+    json(data) {
+      this.body = JSON.stringify(data)
+      return this
+    },
+    end(data) {
+      this.body = data || ''
+      return this
+    }
+  }
+
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 200,
+      headers: res.headers,
+      body: ''
+    }
+  }
+
+  try {
+    if (typeof handler === 'function') {
+      await handler(req, res)
+    } else if (handler.handler) {
+      await handler.handler(req, res)
+    } else if (handler.default) {
+      await handler.default(req, res)
+    } else {
+      await handler(req, res)
+    }
+  } catch (error) {
+    console.error('admin-users-permissions error:', error)
+    res.status(500).json({ error: 'Internal server error' })
+  }
+
+  return {
+    statusCode: res.statusCode,
+    headers: res.headers,
+    body: res.body || JSON.stringify({ error: 'No response' })
+  }
+}

--- a/netlify/functions/admin-users-role.js
+++ b/netlify/functions/admin-users-role.js
@@ -1,0 +1,77 @@
+const handler = require('../../api/admin/users/[id]/role.js')
+
+exports.handler = async (event) => {
+  const pathParameters = event.pathParameters || {}
+  const query = { ...(event.queryStringParameters || {}) }
+
+  if (pathParameters.id && !query.id) {
+    query.id = pathParameters.id
+  }
+
+  const params = { ...pathParameters }
+  if (!params.id && query.id) {
+    params.id = query.id
+  }
+
+  const req = {
+    method: event.httpMethod,
+    query,
+    body: event.body,
+    headers: event.headers,
+    params
+  }
+
+  const res = {
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization'
+    },
+    setHeader(name, value) {
+      this.headers[name] = value
+    },
+    status(code) {
+      this.statusCode = code
+      return this
+    },
+    json(data) {
+      this.body = JSON.stringify(data)
+      return this
+    },
+    end(data) {
+      this.body = data || ''
+      return this
+    }
+  }
+
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 200,
+      headers: res.headers,
+      body: ''
+    }
+  }
+
+  try {
+    if (typeof handler === 'function') {
+      await handler(req, res)
+    } else if (handler.handler) {
+      await handler.handler(req, res)
+    } else if (handler.default) {
+      await handler.default(req, res)
+    } else {
+      await handler(req, res)
+    }
+  } catch (error) {
+    console.error('admin-users-role error:', error)
+    res.status(500).json({ error: 'Internal server error' })
+  }
+
+  return {
+    statusCode: res.statusCode,
+    headers: res.headers,
+    body: res.body || JSON.stringify({ error: 'No response' })
+  }
+}


### PR DESCRIPTION
## Summary
- add Netlify function wrappers that forward admin user role and permissions requests to the API handlers
- ensure path parameters are propagated into both the params object and the query string so handlers receive the user id
- register explicit redirects for the new endpoints in both `_redirects` and `netlify.toml`

## Testing
- `npm run lint` *(fails due to pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d06a2beeb48332ac2400651097adcf