### PR TITLE
Switch application APIs to applications_new table

### DIFF
--- a/api/_lib/analytics/predictiveDashboard.js
+++ b/api/_lib/analytics/predictiveDashboard.js
@@ -169,7 +169,7 @@ async function fetchWorkflowSummary() {
 
 async function fallbackPredictiveSummary() {
   const { data, error } = await supabaseAdminClient
-    .from('applications')
+    .from('applications_new')
     .select('created_at, status, program, updated_at')
     .gte('created_at', new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString())
 

--- a/api/admin/applications/update-status.js
+++ b/api/admin/applications/update-status.js
@@ -39,7 +39,7 @@ module.exports = async function handler(req, res) {
     }
 
     const { data, error } = await supabaseAdminClient
-      .from('applications')
+      .from('applications_new')
       .update(updateData)
       .eq('id', applicationId)
       .select()
@@ -65,7 +65,7 @@ module.exports = async function handler(req, res) {
       actorId: authContext.user.id,
       actorEmail: authContext.user.email,
       actorRoles: authContext.roles,
-      targetTable: 'applications',
+      targetTable: 'applications_new',
       targetId: applicationId,
       metadata: { status, notes }
     })

--- a/api/admin/applications/verify-payment.js
+++ b/api/admin/applications/verify-payment.js
@@ -37,7 +37,7 @@ module.exports = async function handler(req, res) {
     }
 
     const { data, error } = await supabaseAdminClient
-      .from('applications')
+      .from('applications_new')
       .update(updateData)
       .eq('id', applicationId)
       .select()
@@ -53,7 +53,7 @@ module.exports = async function handler(req, res) {
       actorId: authContext.user.id,
       actorEmail: authContext.user.email,
       actorRoles: authContext.roles,
-      targetTable: 'applications',
+      targetTable: 'applications_new',
       targetId: applicationId,
       metadata: { paymentStatus, verificationNotes }
     })

--- a/api/applications/[id].js
+++ b/api/applications/[id].js
@@ -96,7 +96,7 @@ async function handleGet(req, res, { user, isAdmin, roles }, id) {
 
     // Base application query
     const { data: application, error: appError } = await supabaseAdminClient
-      .from('applications')
+      .from('applications_new')
       .select('*')
       .eq('id', id)
       .maybeSingle()
@@ -224,7 +224,7 @@ async function handleGet(req, res, { user, isAdmin, roles }, id) {
       actorId: user.id,
       actorEmail: user.email || null,
       actorRoles: roles,
-      targetTable: 'applications',
+      targetTable: 'applications_new',
       targetId: id,
       metadata: {
         include: Array.from(include),
@@ -250,7 +250,7 @@ async function handlePut(req, res, { user, isAdmin, roles }, id, body) {
     const updates = body
 
     let query = supabaseAdminClient
-      .from('applications')
+      .from('applications_new')
       .update(updates)
       .eq('id', id)
 
@@ -270,7 +270,7 @@ async function handlePut(req, res, { user, isAdmin, roles }, id, body) {
       actorId: user.id,
       actorEmail: user.email || null,
       actorRoles: roles,
-      targetTable: 'applications',
+      targetTable: 'applications_new',
       targetId: id,
       metadata: {
         fields: Object.keys(updates || {}),
@@ -314,7 +314,7 @@ async function handlePatch(req, res, context, id, body) {
 async function handleDelete(req, res, { user, isAdmin, roles }, id) {
   try {
     let query = supabaseAdminClient
-      .from('applications')
+      .from('applications_new')
       .update({ status: 'deleted', updated_at: new Date().toISOString() })
       .eq('id', id)
 
@@ -333,7 +333,7 @@ async function handleDelete(req, res, { user, isAdmin, roles }, id) {
       actorId: user.id,
       actorEmail: user.email || null,
       actorRoles: roles,
-      targetTable: 'applications',
+      targetTable: 'applications_new',
       targetId: id,
       metadata: { isAdmin }
     })
@@ -431,7 +431,7 @@ async function updateApplicationStatus(req, res, { user, isAdmin, roles }, id, b
 
   try {
     const { data: existingApplication, error: fetchError } = await supabaseAdminClient
-      .from('applications')
+      .from('applications_new')
       .select('status, intake, intake_id, intake_name')
       .eq('id', id)
       .maybeSingle()
@@ -458,7 +458,7 @@ async function updateApplicationStatus(req, res, { user, isAdmin, roles }, id, b
     }
 
     const { data, error } = await supabaseAdminClient
-      .from('applications')
+      .from('applications_new')
       .update(updateData)
       .eq('id', id)
       .select()
@@ -498,7 +498,7 @@ async function updateApplicationStatus(req, res, { user, isAdmin, roles }, id, b
       actorId: user.id,
       actorEmail: user.email || null,
       actorRoles: roles,
-      targetTable: 'applications',
+      targetTable: 'applications_new',
       targetId: id,
       metadata: {
         previousStatus: existingApplication.status,
@@ -540,7 +540,7 @@ async function updatePaymentStatus(req, res, { user, isAdmin, roles }, id, body)
     }
 
     const { data, error } = await supabaseAdminClient
-      .from('applications')
+      .from('applications_new')
       .update(updateData)
       .eq('id', id)
       .select()
@@ -587,7 +587,7 @@ async function updatePaymentStatus(req, res, { user, isAdmin, roles }, id, body)
       actorId: user.id,
       actorEmail: user.email || null,
       actorRoles: roles,
-      targetTable: 'applications',
+      targetTable: 'applications_new',
       targetId: id,
       metadata: {
         paymentStatus,
@@ -709,7 +709,7 @@ async function sendNotification(req, res, { user, isAdmin, roles }, id, body) {
 
   try {
     const { data: application, error: fetchError } = await supabaseAdminClient
-      .from('applications')
+      .from('applications_new')
       .select('user_id')
       .eq('id', id)
       .maybeSingle()
@@ -732,7 +732,7 @@ async function sendNotification(req, res, { user, isAdmin, roles }, id, body) {
       })
 
     await supabaseAdminClient
-      .from('applications')
+      .from('applications_new')
       .update({
         admin_feedback: message,
         admin_feedback_date: new Date().toISOString(),
@@ -747,7 +747,7 @@ async function sendNotification(req, res, { user, isAdmin, roles }, id, body) {
       actorId: user.id,
       actorEmail: user.email,
       actorRoles: roles,
-      targetTable: 'applications',
+      targetTable: 'applications_new',
       targetId: id,
       metadata: {
         title,
@@ -920,7 +920,7 @@ async function generateSystemDocument({ applicationId, context, documentType, re
 
 async function fetchApplicationWithRelations(applicationId) {
   const { data: application, error } = await supabaseAdminClient
-    .from('applications')
+    .from('applications_new')
     .select('*')
     .eq('id', applicationId)
     .maybeSingle()
@@ -1308,7 +1308,7 @@ async function syncGrades(req, res, { user, isAdmin, roles }, id, body) {
     // Ensure application belongs to the user unless admin
     if (!isAdmin) {
       const { data: application, error } = await supabaseAdminClient
-        .from('applications')
+        .from('applications_new')
         .select('id, user_id')
         .eq('id', id)
         .maybeSingle()

--- a/api/applications/email-slip.js
+++ b/api/applications/email-slip.js
@@ -35,7 +35,7 @@ module.exports = async function handler(event, context) {
   try {
     // Get application details
     const { data: application, error: appError } = await supabaseAdminClient
-      .from('applications')
+      .from('applications_new')
       .select('*')
       .eq('id', applicationId)
       .eq('user_id', authContext.user.id)
@@ -76,7 +76,7 @@ module.exports = async function handler(event, context) {
       action: 'applications.slip.email',
       actorId: authContext.user.id,
       actorEmail: authContext.user.email,
-      targetTable: 'applications',
+      targetTable: 'applications_new',
       targetId: applicationId,
       metadata: { recipient: application.email }
     })

--- a/api/applications/generate-slip.js
+++ b/api/applications/generate-slip.js
@@ -35,7 +35,7 @@ module.exports = async function handler(event, context) {
   try {
     // Get application details
     const { data: application, error: appError } = await supabaseAdminClient
-      .from('applications')
+      .from('applications_new')
       .select('*')
       .eq('id', applicationId)
       .eq('user_id', authContext.user.id)
@@ -53,7 +53,7 @@ module.exports = async function handler(event, context) {
       action: 'applications.slip.generate',
       actorId: authContext.user.id,
       actorEmail: authContext.user.email,
-      targetTable: 'applications',
+      targetTable: 'applications_new',
       targetId: applicationId,
       metadata: { format: 'html' }
     })

--- a/api/applications/index.js
+++ b/api/applications/index.js
@@ -22,7 +22,7 @@ module.exports = async function handler(req, res) {
       const { page = 0, pageSize = 10, status, mine } = req.query
       
       let query = supabaseAdminClient
-        .from('applications')
+        .from('applications_new')
         .select('*', { count: 'exact' })
         .order('created_at', { ascending: false })
 
@@ -86,7 +86,7 @@ module.exports = async function handler(req, res) {
 
 
       const { data, error } = await supabaseAdminClient
-        .from('applications')
+        .from('applications_new')
         .insert(applicationData)
         .select()
         .single()
@@ -121,7 +121,7 @@ module.exports = async function handler(req, res) {
       }
 
       const { data, error } = await supabaseAdminClient
-        .from('applications')
+        .from('applications_new')
         .insert({
           ...body,
           user_id: authContext.user.id

--- a/docs/guides/MIHAS-KATC-v2-FULL-APP.txt
+++ b/docs/guides/MIHAS-KATC-v2-FULL-APP.txt
@@ -429,7 +429,7 @@ import { createSupabaseServer } from '@/lib/supabase/server';
 export default async function Dashboard(){
   const supabase = createSupabaseServer();
   const { data: { user } } = await supabase.auth.getUser();
-  const { data: apps } = await supabase.from('applications').select('id, status, submission_date').order('created_at', { ascending: false });
+  const { data: apps } = await supabase.from('applications_new').select('id, status, submission_date').order('created_at', { ascending: false });
 
   return (
     <div className="mx-auto max-w-4xl p-6">

--- a/scripts/maintenance/mcp-server.js
+++ b/scripts/maintenance/mcp-server.js
@@ -81,7 +81,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   switch (name) {
     case 'get_applications':
       try {
-        let query = supabase.from('applications').select('*');
+        let query = supabase.from('applications_new').select('*');
         
         if (args.status) query = query.eq('status', args.status);
         if (args.program) query = query.eq('program', args.program);
@@ -109,7 +109,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     case 'get_stats':
       try {
         const { data: applications } = await supabase
-          .from('applications')
+          .from('applications_new')
           .select('status, program, created_at');
         
         const stats = {
@@ -173,7 +173,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 async function main() {
   try {
     // Test Supabase connection
-    const { data, error } = await supabase.from('applications').select('count').limit(1);
+    const { data, error } = await supabase.from('applications_new').select('count').limit(1);
     if (error) {
       console.error('Supabase connection failed:', error.message);
     } else {

--- a/setup-microservices.js
+++ b/setup-microservices.js
@@ -12,7 +12,7 @@ async function setupMicroservices() {
 
   try {
     // Test database connection
-    const { data, error } = await supabaseAdminClient.from('applications').select('count').limit(1)
+    const { data, error } = await supabaseAdminClient.from('applications_new').select('count').limit(1)
     if (error) throw error
     
     console.log('✅ Database connection verified')

--- a/sql/consolidate_applications_table.sql
+++ b/sql/consolidate_applications_table.sql
@@ -1,0 +1,87 @@
+-- Consolidate legacy application records into the unified applications_new table
+-- and provide a compatibility view for any remaining references.
+--
+-- This script is idempotent and can be re-run safely. It performs the
+-- following steps:
+--   1. Copies any records that exist in the legacy applications table but
+--      are missing from applications_new (matching on the primary key).
+--   2. Renames the legacy table to applications_legacy (if it still exists)
+--      so that the canonical name can be reclaimed.
+--   3. Creates a compatibility view named applications that proxies reads and
+--      writes to applications_new, ensuring older integrations continue to
+--      function while everything uses the new storage layer.
+--
+-- NOTE: The copy step automatically determines the overlapping columns between
+--       the legacy and new tables so schema changes do not cause failures.
+
+BEGIN;
+
+-- Step 1: backfill any legacy rows that have not yet been moved into applications_new
+DO $$
+DECLARE
+  shared_columns TEXT;
+  insert_sql TEXT;
+BEGIN
+  IF to_regclass('public.applications') IS NULL THEN
+    RAISE NOTICE 'Legacy applications table not found, skipping backfill.';
+    RETURN;
+  END IF;
+
+  SELECT string_agg(quote_ident(column_name), ', ' ORDER BY column_name)
+  INTO shared_columns
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'applications_new'
+    AND column_name IN (
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'applications'
+    );
+
+  IF shared_columns IS NULL THEN
+    RAISE NOTICE 'No overlapping columns detected between applications and applications_new; skipping backfill.';
+  ELSE
+    insert_sql := format(
+      'INSERT INTO applications_new (%1$s)
+       SELECT %1$s FROM applications legacy
+       WHERE NOT EXISTS (
+         SELECT 1 FROM applications_new unified WHERE unified.id = legacy.id
+       );',
+      shared_columns
+    );
+
+    EXECUTE insert_sql;
+    RAISE NOTICE 'Legacy applications backfill complete.';
+  END IF;
+END $$;
+
+-- Step 2: rename the legacy table so the canonical name can host a view
+DO $$
+BEGIN
+  IF to_regclass('public.applications') IS NOT NULL THEN
+    IF to_regclass('public.applications_legacy') IS NULL THEN
+      EXECUTE 'ALTER TABLE applications RENAME TO applications_legacy';
+      RAISE NOTICE 'Renamed applications table to applications_legacy.';
+    ELSE
+      EXECUTE 'ALTER TABLE applications RENAME TO applications_legacy_backup';
+      RAISE NOTICE 'Renamed applications table to applications_legacy_backup because applications_legacy already exists.';
+    END IF;
+  END IF;
+END $$;
+
+-- Step 3: create a compatibility view so older references continue to work
+DROP VIEW IF EXISTS applications CASCADE;
+CREATE VIEW applications AS
+SELECT * FROM applications_new;
+
+-- Ensure common privileges are preserved for the compatibility view
+DO $$
+BEGIN
+  EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON applications TO anon, authenticated, service_role';
+EXCEPTION
+  WHEN undefined_object THEN
+    RAISE NOTICE 'One or more roles (anon, authenticated, service_role) do not exist in this environment; skipping grants.';
+END $$;
+
+COMMIT;

--- a/src/data/applications.ts
+++ b/src/data/applications.ts
@@ -112,11 +112,11 @@ export const applicationsData = {
         const today = new Date().toISOString().split('T')[0]
         
         const [total, pending, approved, rejected, todayApps] = await Promise.all([
-          supabase.from('applications').select('*', { count: 'exact', head: true }),
-          supabase.from('applications').select('*', { count: 'exact', head: true }).eq('status', 'submitted'),
-          supabase.from('applications').select('*', { count: 'exact', head: true }).eq('status', 'approved'),
-          supabase.from('applications').select('*', { count: 'exact', head: true }).eq('status', 'rejected'),
-          supabase.from('applications').select('*', { count: 'exact', head: true }).gte('created_at', today)
+          supabase.from('applications_new').select('*', { count: 'exact', head: true }),
+          supabase.from('applications_new').select('*', { count: 'exact', head: true }).eq('status', 'submitted'),
+          supabase.from('applications_new').select('*', { count: 'exact', head: true }).eq('status', 'approved'),
+          supabase.from('applications_new').select('*', { count: 'exact', head: true }).eq('status', 'rejected'),
+          supabase.from('applications_new').select('*', { count: 'exact', head: true }).gte('created_at', today)
         ])
 
         const totalCount = total.count || 0
@@ -145,7 +145,7 @@ export const applicationsData = {
       queryKey: ['applications', 'recent-activity'],
       queryFn: async () => {
         const { data } = await supabase
-          .from('applications')
+          .from('applications_new')
           .select('id, full_name, status, created_at, updated_at')
           .order('updated_at', { ascending: false })
           .limit(5)

--- a/test-database-performance.js
+++ b/test-database-performance.js
@@ -35,7 +35,7 @@ async function testDatabasePerformance() {
   console.log('\n2. Testing applications query...')
   const start2 = performance.now()
   const { data: applications, error: appError } = await supabase
-    .from('applications')
+    .from('applications_new')
     .select('*')
     .limit(10)
   const end2 = performance.now()
@@ -50,7 +50,7 @@ async function testDatabasePerformance() {
   console.log('\n3. Testing complex join query...')
   const start3 = performance.now()
   const { data: joinData, error: joinError } = await supabase
-    .from('applications')
+    .from('applications_new')
     .select(`
       *,
       user_profiles(*),

--- a/test-email-system.js
+++ b/test-email-system.js
@@ -97,7 +97,7 @@ async function testSupabaseConnection() {
   console.log('🔗 Testing Supabase connection...')
   
   try {
-    const { data, error } = await supabase.from('applications').select('count').limit(1)
+    const { data, error } = await supabase.from('applications_new').select('count').limit(1)
     if (error) {
       console.log(`❌ Supabase connection failed: ${error.message}`)
       return false

--- a/test-microservices.js
+++ b/test-microservices.js
@@ -34,7 +34,7 @@ async function testMicroservices() {
 
     // Test applications table
     const { data: apps, error: appError } = await supabase
-      .from('applications')
+      .from('applications_new')
       .select('count')
       .limit(1)
 

--- a/test-performance.js
+++ b/test-performance.js
@@ -119,7 +119,7 @@ async function testDatabasePerformance() {
     // Test complex query
     const start2 = performance.now()
     const { data: applications } = await supabase
-      .from('applications')
+      .from('applications_new')
       .select('*, user_profiles(*)')
       .limit(5)
     const end2 = performance.now()


### PR DESCRIPTION
## Summary
- update all application REST handlers to read/write from the applications_new table and adjust audit metadata accordingly
- point helper workflows (documents, status history, payments, notifications, analytics) plus admin utilities at applications_new
- refresh frontend data hooks, maintenance scripts, tests, and documentation to reference the unified table and add an idempotent SQL migration that backfills legacy rows and exposes a compatibility view

## Testing
- `npm run lint` *(fails: existing repository lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d0717c7a6c83329f156f52f0e2695e