### PR TITLE
Refine application service pagination handling

### DIFF
--- a/src/components/admin/ApplicationsTable.tsx
+++ b/src/components/admin/ApplicationsTable.tsx
@@ -5,7 +5,7 @@ import { useApplications } from '@/hooks/useApiServices'
 import { Application } from '@/lib/supabase'
 
 export function ApplicationsTable() {
-  const { data: applications, isLoading, error } = useApplications()
+  const { data: applications = [], isLoading, error } = useApplications()
 
   if (isLoading) return <div>Loading applications...</div>
   if (error) return <div>Error loading applications</div>
@@ -33,7 +33,7 @@ export function ApplicationsTable() {
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-200">
-          {applications?.map((app: Application) => (
+          {applications.map((app: Application) => (
             <tr key={app.id}>
               <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
                 {app.application_number}

--- a/src/hooks/useApiServices.ts
+++ b/src/hooks/useApiServices.ts
@@ -30,9 +30,12 @@ export const useRegister = () => {
 
 // Application hooks
 export const useApplications = () => {
-  return useQuery<Application[] | null>({
+  return useQuery<Application[]>({
     queryKey: ['applications'],
-    queryFn: applicationService.getAll
+    queryFn: async () => {
+      const response = await applicationService.getAll()
+      return response?.applications ?? []
+    }
   })
 }
 

--- a/src/pages/student/Dashboard.tsx
+++ b/src/pages/student/Dashboard.tsx
@@ -117,7 +117,7 @@ export default function StudentDashboard() {
         mine: true
       })
 
-      if (draftResponse.applications && draftResponse.applications.length > 0) {
+      if (draftResponse?.applications && draftResponse.applications.length > 0) {
         setHasDraft(true)
         setDraftData(draftResponse.applications[0])
       }
@@ -131,7 +131,7 @@ export default function StudentDashboard() {
         mine: true
       })
 
-      setApplications((applicationsResponse.applications || []) as Application[])
+      setApplications((applicationsResponse?.applications || []) as Application[])
 
       // Load programs and intakes
       const [programsResponse, intakesResponse] = await Promise.all([

--- a/src/services/applications.ts
+++ b/src/services/applications.ts
@@ -1,6 +1,14 @@
-import { Application } from '@/lib/supabase'
+import type { Application } from '@/lib/supabase'
 
 import { apiClient, buildQueryString, QueryParams } from './client'
+
+export interface PaginatedApplicationsResponse {
+  applications: Application[]
+  totalCount: number
+  page: number
+  pageSize: number
+  stats?: Record<string, unknown>
+}
 
 type ApplicationIncludeOptions = {
   include?: string[]
@@ -10,11 +18,15 @@ type ApplicationPayload = Partial<Application>
 
 export const applicationService = {
   list: (params?: QueryParams) =>
-    apiClient.request<Application[]>(`/api/applications${buildQueryString(params ?? {})}`),
+    apiClient.request<PaginatedApplicationsResponse>(
+      `/api/applications${buildQueryString(params ?? {})}`
+    ),
 
   // Alias for backward compatibility
   getAll: (params?: QueryParams) =>
-    apiClient.request<Application[]>(`/api/applications${buildQueryString(params ?? {})}`),
+    apiClient.request<PaginatedApplicationsResponse>(
+      `/api/applications${buildQueryString(params ?? {})}`
+    ),
 
   getById: (id: string, options?: ApplicationIncludeOptions) =>
     apiClient.request<any>(

--- a/tests/unit/hooks/useApplications.test.ts
+++ b/tests/unit/hooks/useApplications.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createElement, type ReactNode } from 'react'
+
+import { useApplications } from '@/hooks/useApiServices'
+import type { Application } from '@/lib/supabase'
+import { applicationService, type PaginatedApplicationsResponse } from '@/services/applications'
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: null,
+    loading: false,
+    signIn: async () => ({}),
+    signUp: async () => ({}),
+    signOut: async () => {}
+  })
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabaseClient: () => ({
+    auth: {
+      getSession: async () => ({ data: { session: null } })
+    }
+  })
+}))
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false }
+    }
+  })
+
+const createWrapper = (queryClient: QueryClient) => {
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient, children })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useApplications', () => {
+  it('returns applications array when service resolves paginated response', async () => {
+    const mockApplication: Application = {
+      id: 'app-1',
+      application_number: 'APP-001',
+      user_id: 'user-1',
+      full_name: 'John Doe',
+      date_of_birth: '1990-01-01',
+      sex: 'Male',
+      phone: '+26000000000',
+      email: 'john.doe@example.com',
+      residence_town: 'Lusaka',
+      program: 'Clinical Medicine',
+      intake: 'January 2025',
+      institution: 'MIHAS',
+      application_fee: 150,
+      payment_status: 'pending_review',
+      status: 'submitted',
+      public_tracking_code: 'TRACK-001',
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-02T00:00:00Z'
+    }
+
+    const mockResponse: PaginatedApplicationsResponse = {
+      applications: [mockApplication],
+      totalCount: 1,
+      page: 0,
+      pageSize: 25
+    }
+
+    const getAllSpy = vi
+      .spyOn(applicationService, 'getAll')
+      .mockResolvedValue(mockResponse)
+
+    const queryClient = createQueryClient()
+    const wrapper = createWrapper(queryClient)
+
+    const { result } = renderHook(() => useApplications(), { wrapper })
+
+    try {
+      await waitFor(() => {
+        expect(result.current.data).toEqual(mockResponse.applications)
+      })
+
+      expect(getAllSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      queryClient.clear()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- add a PaginatedApplicationsResponse contract to the application service and make list/getAll return it
- update useApplications and consumers to work with the unwrapped application array
- add a focused unit test that mocks the paginated service response and ensures the hook returns the applications list

## Testing
- npm run test:unit -- tests/unit/hooks/useApplications.test.ts
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68d0760b7a68833284e023e671377ef5