### PR TITLE
Fix Netlify application detail rewrite and add tests

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -10,7 +10,7 @@
 /api/analytics/telemetry /.netlify/functions/analytics-telemetry 200
 /api/analytics/predictive-dashboard /.netlify/functions/analytics-predictive-dashboard 200
 /api/applications/bulk /.netlify/functions/applications-bulk 200
-/api/applications/:id /.netlify/functions/applications-id 200
+/api/applications/:id /.netlify/functions/applications-id?id=:id 200
 /api/auth/login /.netlify/functions/auth-login 200
 /api/auth/register /.netlify/functions/auth-register 200
 /api/auth/signin /.netlify/functions/auth-signin 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -48,6 +48,12 @@
   force = true
 
 [[redirects]]
+  from = "/api/applications/:id"
+  to = "/.netlify/functions/applications-id?id=:id"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/api/notifications/dispatch-channel"
   to = "/.netlify/functions/notifications-dispatch-channel"
   status = 200

--- a/netlify/functions/applications-id.js
+++ b/netlify/functions/applications-id.js
@@ -1,61 +1,110 @@
-const handler = require('../../api/applications/[id].js')
+let cachedHandlerModule
 
-exports.handler = async (event, context) => {
-  // Extract ID from path or query
-  const pathParts = event.path ? event.path.split('/') : []
-  const idFromPath = pathParts[pathParts.length - 1]
-  const idFromQuery = event.queryStringParameters?.id
-  const applicationId = idFromPath !== 'applications-id' ? idFromPath : idFromQuery
-  
-  const req = {
-    method: event.httpMethod,
-    query: event.queryStringParameters || {},
-    body: event.body,
-    headers: event.headers,
-    params: { id: applicationId }
+function loadHandlerModule() {
+  if (!cachedHandlerModule) {
+    cachedHandlerModule = require('../../api/applications/[id].js')
   }
-  
-  const res = {
-    statusCode: 200,
-    headers: { 
-      'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type, Authorization'
-    },
-    setHeader: function(name, value) { this.headers[name] = value },
-    status: function(code) { this.statusCode = code; return this },
-    json: function(data) { this.body = JSON.stringify(data); return this },
-    end: function(data) { this.body = data || ''; return this }
+  return cachedHandlerModule
+}
+
+function resolveHandler(handlerOverride) {
+  if (handlerOverride) {
+    return handlerOverride
   }
 
-  // Handle OPTIONS preflight
-  if (event.httpMethod === 'OPTIONS') {
-    return {
-      statusCode: 200,
-      headers: res.headers,
-      body: ''
-    }
+  const module = loadHandlerModule()
+
+  if (typeof module === 'function') {
+    return module
   }
 
-  try {
-    if (typeof handler === 'function') {
-      await handler(req, res)
-    } else if (handler.handler) {
-      await handler.handler(req, res)
-    } else if (handler.default) {
-      await handler.default(req, res)
+  if (typeof module?.handler === 'function') {
+    return module.handler
+  }
+
+  if (typeof module?.default === 'function') {
+    return module.default
+  }
+
+  return module
+}
+
+function createApplicationsIdHandler(handlerOverride) {
+  const getHandler = () => resolveHandler(handlerOverride)
+
+  return async (event, context) => {
+    // Extract ID from path or query
+    const pathParts = event.path ? event.path.split('/') : []
+    const idFromPath = pathParts[pathParts.length - 1]
+    const idFromQuery = event.queryStringParameters?.id
+    const applicationId = idFromPath !== 'applications-id' ? idFromPath : idFromQuery
+
+    if (applicationId) {
+      console.log('applications-id resolved request parameters', {
+        applicationId,
+        source: idFromPath !== 'applications-id' ? 'path' : 'query'
+      })
     } else {
-      await handler(req, res)
+      console.warn('applications-id missing identifier for request', {
+        path: event.path,
+        query: event.queryStringParameters
+      })
     }
-  } catch (error) {
-    console.error('applications-id error:', error)
-    res.status(500).json({ error: 'Internal server error' })
-  }
 
-  return {
-    statusCode: res.statusCode,
-    headers: res.headers,
-    body: res.body || JSON.stringify({ error: 'No response' })
+    const req = {
+      method: event.httpMethod,
+      query: event.queryStringParameters || {},
+      body: event.body,
+      headers: event.headers,
+      params: { id: applicationId }
+    }
+
+    const res = {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization'
+      },
+      setHeader: function(name, value) { this.headers[name] = value },
+      status: function(code) { this.statusCode = code; return this },
+      json: function(data) { this.body = JSON.stringify(data); return this },
+      end: function(data) { this.body = data || ''; return this }
+    }
+
+    // Handle OPTIONS preflight
+    if (event.httpMethod === 'OPTIONS') {
+      return {
+        statusCode: 200,
+        headers: res.headers,
+        body: ''
+      }
+    }
+
+    try {
+      const handler = getHandler()
+      if (typeof handler === 'function') {
+        await handler(req, res)
+      } else if (handler?.handler) {
+        await handler.handler(req, res)
+      } else if (handler?.default) {
+        await handler.default(req, res)
+      } else {
+        await handler(req, res)
+      }
+    } catch (error) {
+      console.error('applications-id error:', error)
+      res.status(500).json({ error: 'Internal server error' })
+    }
+
+    return {
+      statusCode: res.statusCode,
+      headers: res.headers,
+      body: res.body || JSON.stringify({ error: 'No response' })
+    }
   }
 }
+
+exports.handler = createApplicationsIdHandler()
+exports.createApplicationsIdHandler = createApplicationsIdHandler

--- a/tests/api/applications-detail.test.js
+++ b/tests/api/applications-detail.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import './setup.js'
+
+const detailHandler = vi.fn(async (req, res) => {
+  res.status(200).json({ receivedId: req.params.id })
+})
+
+describe('applications detail Netlify function', () => {
+  beforeEach(() => {
+    detailHandler.mockClear()
+  })
+
+  it('passes path parameter IDs through to the handler', async () => {
+    const { createApplicationsIdHandler } = await import('../../netlify/functions/applications-id.js')
+    const handler = createApplicationsIdHandler(detailHandler)
+
+    const event = {
+      httpMethod: 'GET',
+      path: '/api/applications/app-123',
+      headers: {},
+      queryStringParameters: {}
+    }
+
+    const response = await handler(event, {})
+
+    expect(detailHandler).toHaveBeenCalledTimes(1)
+    expect(detailHandler.mock.calls[0][0].params.id).toBe('app-123')
+    expect(response.statusCode).toBe(200)
+    expect(JSON.parse(response.body)).toEqual({ receivedId: 'app-123' })
+  })
+
+  it('uses query string ID when invoked via direct function path', async () => {
+    const { createApplicationsIdHandler } = await import('../../netlify/functions/applications-id.js')
+    const handler = createApplicationsIdHandler(detailHandler)
+
+    const event = {
+      httpMethod: 'GET',
+      path: '/.netlify/functions/applications-id',
+      headers: {},
+      queryStringParameters: { id: 'app-456' }
+    }
+
+    const response = await handler(event, {})
+
+    expect(detailHandler).toHaveBeenCalledTimes(1)
+    expect(detailHandler.mock.calls[0][0].params.id).toBe('app-456')
+    expect(response.statusCode).toBe(200)
+    expect(JSON.parse(response.body)).toEqual({ receivedId: 'app-456' })
+  })
+})


### PR DESCRIPTION
## Summary
- update the Netlify redirect for `/api/applications/:id` in both `_redirects` and `netlify.toml` to append the `id` query parameter so the original identifier is preserved
- refactor the `applications-id` Netlify function to log the resolved identifier, support dependency injection for testing, and expose a factory for reuse
- add a focused Vitest spec that verifies the wrapper forwards path and query string IDs to the downstream handler

## Testing
- npx vitest run tests/api/applications-detail.test.js
- Manually verified `GET /api/applications/<id>` through `netlify dev` with `curl http://localhost:8888/api/applications/log-test-789`


------
https://chatgpt.com/codex/tasks/task_e_68d07cf73504833296f88bf41b8f415a