### PR TITLE
Replace admin alerts with toast notifications

### DIFF
--- a/src/pages/admin/AIInsights.tsx
+++ b/src/pages/admin/AIInsights.tsx
@@ -8,6 +8,7 @@ import { Card } from '@/components/ui/Card'
 import { Button } from '@/components/ui/Button'
 import { workflowAutomation } from '@/lib/workflowAutomation'
 import { multiChannelNotifications } from '@/lib/multiChannelNotifications'
+import { useToast } from '@/components/ui/Toast'
 
 interface AIInsightsStats {
   totalPredictions: number
@@ -20,6 +21,7 @@ export default function AIInsights() {
   const { profile } = useProfileQuery()
   const { isAdmin: hasAdminRole } = useRoleQuery()
   const isAdmin = hasAdminRole || isAdminRole(profile?.role)
+  const { showSuccess, showError } = useToast()
   const [stats, setStats] = useState<AIInsightsStats>({
     totalPredictions: 0,
     automationRuns: 0,
@@ -58,10 +60,12 @@ export default function AIInsights() {
   const runWorkflowMaintenance = async () => {
     try {
       const result = await workflowAutomation.runScheduledWorkflows()
-      alert(`Workflow maintenance completed. Processed: ${result.processed}, Errors: ${result.errors}`)
+      showSuccess('Workflow maintenance completed', `Processed: ${result.processed}, Errors: ${result.errors}`)
     } catch (error) {
       console.error('Workflow maintenance failed:', error)
-      alert('Workflow maintenance failed. Please try again.')
+      const fallbackMessage = 'Workflow maintenance failed. Please try again.'
+      const message = error instanceof Error ? error.message : fallbackMessage
+      showError('Workflow maintenance failed', message !== fallbackMessage ? message : undefined)
     }
   }
 

--- a/src/pages/admin/Analytics.tsx
+++ b/src/pages/admin/Analytics.tsx
@@ -10,6 +10,7 @@ import { exportReport, ReportExportData, ReportFormat } from '@/lib/reportExport
 import { TrendingUp, Users, FileText, CheckCircle, Download, Plus, Edit, Trash2, RefreshCw, Eye, Filter, BarChart3 } from 'lucide-react'
 import { useRoleQuery } from '@/hooks/auth/useRoleQuery'
 import { isReportManagerRole } from '@/lib/auth/roles'
+import { useToast } from '@/components/ui/Toast'
 
 export default function Analytics() {
   const [loading, setLoading] = useState(true)
@@ -41,6 +42,7 @@ export default function Analytics() {
   } = useRoleQuery()
   const canManageReports = isReportManagerRole(userRole?.role)
   const roleStatusLoading = roleLoading || roleFetching
+  const { showSuccess, showError, showInfo } = useToast()
 
   useEffect(() => {
     loadAnalytics()
@@ -111,11 +113,12 @@ export default function Analytics() {
       setShowCreateDialog(false)
       setFormData({})
       await loadAnalytics()
-      alert('Record created successfully!')
+      showSuccess('Record created successfully!')
     } catch (error) {
       console.error('Failed to create record:', error)
-      const message = error instanceof Error ? error.message : 'Failed to create record'
-      alert(message)
+      const fallbackMessage = 'Failed to create record'
+      const message = error instanceof Error ? error.message : fallbackMessage
+      showError(fallbackMessage, message !== fallbackMessage ? message : undefined)
     }
   }
 
@@ -135,11 +138,12 @@ export default function Analytics() {
       setSelectedItem(null)
       setFormData({})
       await loadAnalytics()
-      alert('Record updated successfully!')
+      showSuccess('Record updated successfully!')
     } catch (error) {
       console.error('Failed to update record:', error)
-      const message = error instanceof Error ? error.message : 'Failed to update record'
-      alert(message)
+      const fallbackMessage = 'Failed to update record'
+      const message = error instanceof Error ? error.message : fallbackMessage
+      showError(fallbackMessage, message !== fallbackMessage ? message : undefined)
     }
   }
 
@@ -161,11 +165,12 @@ export default function Analytics() {
       setSelectedItem(null)
       await loadAnalytics()
       await loadAutomatedReports()
-      alert('Record deleted successfully!')
+      showSuccess('Record deleted successfully!')
     } catch (error) {
       console.error('Failed to delete record:', error)
-      const message = error instanceof Error ? error.message : 'Failed to delete record'
-      alert(message)
+      const fallbackMessage = 'Failed to delete record'
+      const message = error instanceof Error ? error.message : fallbackMessage
+      showError(fallbackMessage, message !== fallbackMessage ? message : undefined)
     }
   }
 
@@ -183,11 +188,12 @@ export default function Analytics() {
 
       await exportReport(reportData, exportFormat, reportName)
 
-      alert('Analytics report generated and downloaded successfully!')
+      showInfo('Analytics report ready', 'The report was generated and downloaded successfully.')
     } catch (error) {
       console.error('Failed to generate report:', error)
-      const message = error instanceof Error ? error.message : 'Failed to generate report'
-      alert(message)
+      const fallbackMessage = 'Failed to generate report'
+      const message = error instanceof Error ? error.message : fallbackMessage
+      showError(fallbackMessage, message !== fallbackMessage ? message : undefined)
     }
   }
 
@@ -696,10 +702,12 @@ export default function Analytics() {
                                     const format = (report as any).format || (report.reportData?.metadata?.exportFormat as ReportFormat) || 'json'
                                     const reportData: ReportExportData = report.reportData || (report as any).report_data
                                     await exportReport(reportData, format, report.reportName || (report as any).report_name || 'automated_report')
-                                    alert('Report downloaded successfully!')
+                                    showInfo('Report downloaded', 'The report has been downloaded successfully.')
                                   } catch (error) {
                                     console.error('Failed to download report:', error)
-                                    alert(error instanceof Error ? error.message : 'Failed to download report')
+                                    const fallbackMessage = 'Failed to download report'
+                                    const message = error instanceof Error ? error.message : fallbackMessage
+                                    showError(fallbackMessage, message !== fallbackMessage ? message : undefined)
                                   }
                                 }}
                                 className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 text-xs"


### PR DESCRIPTION
## Summary
- switch Analytics admin page to use the toast hook and surface CRUD/report feedback via non-blocking toasts
- update AI Insights maintenance handler to display toast notifications instead of window alerts

## Testing
- npm run lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d07f7b56f8833296cd3b22ba122b25