### PR TITLE
Add advanced filters and stats to applications API

### DIFF
--- a/api/applications/index.js
+++ b/api/applications/index.js
@@ -1,43 +1,156 @@
 const { supabaseAdminClient, getUserFromRequest } = require('../_lib/supabaseClient')
 
-module.exports = async function handler(req, res) {
-  // Add CORS headers
+const APPLICATION_STATUSES = ['draft', 'submitted', 'under_review', 'approved', 'rejected']
+
+const SORT_COLUMN_MAP = {
+  date: 'created_at',
+  name: 'full_name',
+  status: 'status',
+  program: 'program',
+  paymentStatus: 'payment_status',
+  created_at: 'created_at',
+  full_name: 'full_name'
+}
+
+const dependencies = {
+  supabaseClient: supabaseAdminClient,
+  getUserFromRequest
+}
+
+function sanitizeSearchTerm(value = '') {
+  return value
+    .trim()
+    .replace(/[%_]/g, match => `\\${match}`)
+    .replace(/,/g, '\\,')
+}
+
+function parseBoolean(value) {
+  if (typeof value === 'boolean') return value
+  if (typeof value !== 'string') return false
+  return ['true', '1', 'yes', 'on'].includes(value.toLowerCase())
+}
+
+function determineSortColumn(sortBy) {
+  if (typeof sortBy === 'string' && SORT_COLUMN_MAP[sortBy]) {
+    return SORT_COLUMN_MAP[sortBy]
+  }
+
+  if (typeof sortBy === 'string' && /^[a-z0-9_]+$/i.test(sortBy)) {
+    return sortBy
+  }
+
+  return 'created_at'
+}
+
+function applyFilters(queryBuilder, filters = {}, { includeStatus = true } = {}) {
+  let nextQuery = queryBuilder
+
+  if (filters.mine && filters.userId) {
+    nextQuery = nextQuery.eq('user_id', filters.userId)
+  }
+
+  if (includeStatus && filters.status) {
+    nextQuery = nextQuery.eq('status', filters.status)
+  }
+
+  if (filters.program) {
+    nextQuery = nextQuery.eq('program', filters.program)
+  }
+
+  if (filters.institution) {
+    nextQuery = nextQuery.eq('institution', filters.institution)
+  }
+
+  if (filters.paymentStatus) {
+    nextQuery = nextQuery.eq('payment_status', filters.paymentStatus)
+  }
+
+  if (filters.startDate) {
+    nextQuery = nextQuery.gte('created_at', filters.startDate)
+  }
+
+  if (filters.endDate) {
+    nextQuery = nextQuery.lte('created_at', filters.endDate)
+  }
+
+  if (filters.search) {
+    const sanitized = sanitizeSearchTerm(filters.search)
+    if (sanitized) {
+      const pattern = `%${sanitized}%`
+      nextQuery = nextQuery.or(
+        ['full_name', 'email', 'application_number'].map(field => `${field}.ilike.${pattern}`).join(',')
+      )
+    }
+  }
+
+  return nextQuery
+}
+
+async function handler(req, res) {
   res.setHeader('Access-Control-Allow-Origin', '*')
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
-  
+
   if (req.method === 'OPTIONS') {
     return res.status(200).end()
   }
 
   console.log(`${req.method} /api/applications - Headers:`, req.headers)
-  
+
   if (req.method === 'GET') {
     try {
-      const authContext = await getUserFromRequest(req)
+      const authContext = await dependencies.getUserFromRequest(req)
       if (authContext.error) {
         return res.status(401).json({ error: authContext.error })
       }
 
-      const { page = 0, pageSize = 10, status, mine } = req.query
-      
-      let query = supabaseAdminClient
-        .from('applications_new')
-        .select('*', { count: 'exact' })
-        .order('created_at', { ascending: false })
+      const {
+        page = 0,
+        pageSize = 10,
+        status,
+        mine,
+        search,
+        program,
+        institution,
+        paymentStatus,
+        startDate,
+        endDate,
+        sortBy,
+        sortOrder,
+        includeStats
+      } = req.query
 
-      if (status) {
-        query = query.eq('status', status)
+      const pageNumber = Number.isNaN(parseInt(page, 10)) ? 0 : parseInt(page, 10)
+      const pageSizeNumber = Number.isNaN(parseInt(pageSize, 10)) ? 10 : parseInt(pageSize, 10)
+
+      const from = pageNumber * pageSizeNumber
+      const to = from + pageSizeNumber - 1
+
+      const filterOptions = {
+        userId: authContext.user?.id,
+        mine: parseBoolean(mine),
+        status,
+        search,
+        program,
+        institution,
+        paymentStatus,
+        startDate,
+        endDate
       }
 
-      if (mine === 'true') {
-        query = query.eq('user_id', authContext.user.id)
-      }
+      const sortColumn = determineSortColumn(sortBy)
+      const sortAscending = typeof sortOrder === 'string' && sortOrder.toLowerCase() === 'asc'
 
-      const from = parseInt(page) * parseInt(pageSize)
-      const to = from + parseInt(pageSize) - 1
-      
-      query = query.range(from, to)
+      let query = applyFilters(
+        dependencies.supabaseClient
+          .from('applications_new')
+          .select('*', { count: 'exact' }),
+        filterOptions
+      )
+
+      query = query
+        .order(sortColumn, { ascending: sortAscending })
+        .range(from, to)
 
       const { data, error, count } = await query
 
@@ -45,11 +158,56 @@ module.exports = async function handler(req, res) {
         return res.status(400).json({ error: error.message })
       }
 
+      let stats
+
+      if (parseBoolean(includeStats)) {
+        const baseCountQuery = applyFilters(
+          dependencies.supabaseClient
+            .from('applications_new')
+            .select('id', { count: 'exact', head: true }),
+          filterOptions,
+          { includeStatus: false }
+        )
+
+        const { count: baseCount, error: baseCountError } = await baseCountQuery
+
+        if (baseCountError) {
+          return res.status(400).json({ error: baseCountError.message })
+        }
+
+        const statusBreakdown = {}
+
+        for (const statusValue of APPLICATION_STATUSES) {
+          const statusQuery = applyFilters(
+            dependencies.supabaseClient
+              .from('applications_new')
+              .select('id', { count: 'exact', head: true })
+              .eq('status', statusValue),
+            filterOptions,
+            { includeStatus: false }
+          )
+
+          const { count: statusCount, error: statusError } = await statusQuery
+
+          if (statusError) {
+            return res.status(400).json({ error: statusError.message })
+          }
+
+          statusBreakdown[statusValue] = statusCount || 0
+        }
+
+        stats = {
+          total: baseCount || 0,
+          statusBreakdown
+        }
+      }
+
       return res.json({
         applications: data || [],
         totalCount: count || 0,
-        page: parseInt(page),
-        pageSize: parseInt(pageSize)
+        page: pageNumber,
+        pageSize: pageSizeNumber,
+        ...(stats ? { stats } : {})
       })
     } catch (error) {
       console.error('Applications list error:', error)
@@ -59,12 +217,11 @@ module.exports = async function handler(req, res) {
 
   if (req.method === 'POST') {
     try {
-      const authContext = await getUserFromRequest(req)
+      const authContext = await dependencies.getUserFromRequest(req)
       if (authContext.error) {
         return res.status(401).json({ error: authContext.error })
       }
 
-      // Parse body if it's a string (Netlify functions)
       let body = req.body
       if (typeof body === 'string') {
         try {
@@ -77,15 +234,12 @@ module.exports = async function handler(req, res) {
       console.log('POST /api/applications - Request body:', JSON.stringify(body, null, 2))
       console.log('POST /api/applications - User ID:', authContext.user.id)
 
-      // Development mode defaults
       const applicationData = {
         ...body,
         user_id: authContext.user.id
       }
 
-
-
-      const { data, error } = await supabaseAdminClient
+      const { data, error } = await dependencies.supabaseClient
         .from('applications_new')
         .insert(applicationData)
         .select()
@@ -105,12 +259,11 @@ module.exports = async function handler(req, res) {
 
   if (req.method === 'PUT') {
     try {
-      const authContext = await getUserFromRequest(req)
+      const authContext = await dependencies.getUserFromRequest(req)
       if (authContext.error) {
         return res.status(401).json({ error: authContext.error })
       }
 
-      // Parse body if it's a string (Netlify functions)
       let body = req.body
       if (typeof body === 'string') {
         try {
@@ -120,7 +273,7 @@ module.exports = async function handler(req, res) {
         }
       }
 
-      const { data, error } = await supabaseAdminClient
+      const { data, error } = await dependencies.supabaseClient
         .from('applications_new')
         .insert({
           ...body,
@@ -143,3 +296,23 @@ module.exports = async function handler(req, res) {
   res.setHeader('Allow', 'GET,POST,PUT')
   return res.status(405).json({ error: 'Method not allowed' })
 }
+
+handler.__testables__ = {
+  sanitizeSearchTerm,
+  parseBoolean,
+  determineSortColumn,
+  applyFilters,
+  APPLICATION_STATUSES,
+  setDependencies: (overrides = {}) => {
+    if (overrides.supabaseClient) {
+      dependencies.supabaseClient = overrides.supabaseClient
+    }
+    if (overrides.getUserFromRequest) {
+      dependencies.getUserFromRequest = overrides.getUserFromRequest
+    }
+    return { ...dependencies }
+  },
+  getDependencies: () => ({ ...dependencies })
+}
+
+module.exports = handler

--- a/tests/api/setup.js
+++ b/tests/api/setup.js
@@ -1,30 +1,45 @@
 import { vi } from 'vitest'
 
 // Mock Supabase client
-const createMockQueryBuilder = () => {
-  const mockResolvedValue = vi.fn().mockResolvedValue({ data: [], error: null })
-  
-  return {
-    select: vi.fn(() => ({ mockResolvedValue })),
-    insert: vi.fn(() => ({ mockResolvedValue })),
-    update: vi.fn(() => ({ mockResolvedValue })),
-    delete: vi.fn(() => ({ mockResolvedValue })),
-    eq: vi.fn().mockReturnThis(),
-    gte: vi.fn().mockReturnThis(),
-    lte: vi.fn().mockReturnThis(),
-    order: vi.fn().mockReturnThis(),
-    limit: vi.fn().mockReturnThis(),
-    single: vi.fn().mockResolvedValue({ data: {}, error: null }),
-    then: vi.fn().mockResolvedValue({ data: [], error: null }),
-    mockResolvedValue
-  }
+export const createMockQueryBuilder = () => {
+  const builder = {}
+
+  builder.execute = vi.fn().mockResolvedValue({ data: [], error: null, count: 0 })
+  builder.select = vi.fn(() => builder)
+  builder.insert = vi.fn(() => builder)
+  builder.update = vi.fn(() => builder)
+  builder.delete = vi.fn(() => builder)
+  builder.eq = vi.fn(() => builder)
+  builder.gte = vi.fn(() => builder)
+  builder.lte = vi.fn(() => builder)
+  builder.or = vi.fn(() => builder)
+  builder.ilike = vi.fn(() => builder)
+  builder.in = vi.fn(() => builder)
+  builder.order = vi.fn(() => builder)
+  builder.range = vi.fn(() => builder)
+  builder.limit = vi.fn(() => builder)
+  builder.single = vi.fn().mockResolvedValue({ data: {}, error: null })
+  builder.maybeSingle = vi.fn().mockResolvedValue({ data: null, error: null })
+  builder.mockResolvedValue = vi.fn((value) => {
+    builder.execute.mockResolvedValue(value)
+    return builder
+  })
+  builder.mockResolvedValueOnce = vi.fn((value) => {
+    builder.execute.mockResolvedValueOnce(value)
+    return builder
+  })
+  builder.then = vi.fn((onFulfilled, onRejected) => builder.execute().then(onFulfilled, onRejected))
+  builder.catch = vi.fn((onRejected) => builder.execute().catch(onRejected))
+
+  return builder
 }
 
 export const mockSupabaseClient = {
   from: vi.fn(() => createMockQueryBuilder()),
   auth: {
     signUp: vi.fn().mockResolvedValue({ data: { user: { id: '123' } }, error: null }),
-    signInWithPassword: vi.fn().mockResolvedValue({ data: { user: { id: '123' } }, error: null })
+    signInWithPassword: vi.fn().mockResolvedValue({ data: { user: { id: '123' } }, error: null }),
+    getUser: vi.fn().mockResolvedValue({ data: { user: { id: '123' } }, error: null })
   },
   storage: {
     from: vi.fn(() => ({


### PR DESCRIPTION
## Summary
- add reusable helpers and dependency injection to the applications API so GET requests can handle search, program, institution, payment, date, sorting, and optional status stats responses
- expand Vitest coverage to validate the new filtering paths, stats payload, and creation flow using mocked Supabase builders
- extend the shared test Supabase mock with additional chain helpers and an auth getUser stub to support the new tests

## Testing
- `npx vitest run tests/api/applications.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68d081fc2d208332921b9c8d66cd1581