### PR TITLE
Restrict non-admin applications queries

### DIFF
--- a/api/applications/index.js
+++ b/api/applications/index.js
@@ -126,9 +126,14 @@ async function handler(req, res) {
       const from = pageNumber * pageSizeNumber
       const to = from + pageSizeNumber - 1
 
+      const userId = authContext.user?.id
+      const isAdmin = Boolean(authContext.isAdmin)
+      const mineRequested = parseBoolean(mine)
+      const shouldFilterByUser = Boolean(userId) && (!isAdmin || mineRequested)
+
       const filterOptions = {
-        userId: authContext.user?.id,
-        mine: parseBoolean(mine),
+        userId,
+        mine: shouldFilterByUser,
         status,
         search,
         program,


### PR DESCRIPTION
## Summary
- ensure non-admin application listings automatically filter to the authenticated user
- keep admin behaviour intact while still allowing admins to use the mine filter
- add regression tests covering default non-admin behaviour and admin access

## Testing
- npx vitest run tests/api/applications.test.js --watch=false
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0e27963948332b933c69d2ac75a9e