### PR TITLE
Add local shim for Netlify scheduled functions plugin

### DIFF
--- a/netlify/plugins/plugin-scheduled-functions/index.js
+++ b/netlify/plugins/plugin-scheduled-functions/index.js
@@ -1,0 +1,14 @@
+/**
+ * Minimal placeholder implementation of the Netlify Scheduled Functions plugin.
+ *
+ * The official plugin is not available in this environment, so this shim avoids
+ * local development failures by registering the hooks expected by Netlify CLI.
+ */
+module.exports = {
+  name: '@netlify/plugin-scheduled-functions',
+  // Netlify Build expects plugin hooks to be functions. We provide no-ops so
+  // that the CLI can continue to run without throwing missing plugin errors.
+  async onPreBuild() {
+    console.log('Using local @netlify/plugin-scheduled-functions shim.');
+  },
+};

--- a/netlify/plugins/plugin-scheduled-functions/package.json
+++ b/netlify/plugins/plugin-scheduled-functions/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@netlify/plugin-scheduled-functions",
+  "version": "0.0.1",
+  "main": "index.js"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "zustand": "^4.5.5"
       },
       "devDependencies": {
+        "@netlify/plugin-scheduled-functions": "file:netlify/plugins/plugin-scheduled-functions",
         "@playwright/test": "^1.47.0",
         "@testing-library/react": "^14.2.2",
         "@types/node": "^20.19.16",
@@ -81,6 +82,11 @@
         "typescript-eslint": "^8.44.0",
         "vitest": "^3.2.4"
       }
+    },
+    "netlify/plugins/plugin-scheduled-functions": {
+      "name": "@netlify/plugin-scheduled-functions",
+      "version": "0.0.1",
+      "dev": true
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -2572,6 +2578,10 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@netlify/plugin-scheduled-functions": {
+      "resolved": "netlify/plugins/plugin-scheduled-functions",
+      "link": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "jsdom": "^27.0.0",
     "terser": "^5.32.0",
     "typescript-eslint": "^8.44.0",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "@netlify/plugin-scheduled-functions": "file:netlify/plugins/plugin-scheduled-functions"
   }
 }


### PR DESCRIPTION
## Summary
- add the Netlify scheduled functions plugin to devDependencies using a local file reference
- create a minimal local implementation of the plugin so the Netlify CLI can load it during development
- update the lockfile after installing dependencies

## Testing
- npm install
- npx netlify dev --offline --port 8888

------
https://chatgpt.com/codex/tasks/task_e_68d239cce700833291f4c0bcc122f64c