### PR TITLE
Add Netlify wrappers for admin application endpoints

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -6,6 +6,8 @@
 /api/admin/users/:id /.netlify/functions/admin-users-id 200
 /api/admin/users/:id/role /.netlify/functions/admin-users-role?id=:id 200
 /api/admin/users/:id/permissions /.netlify/functions/admin-users-permissions?id=:id 200
+/api/admin/applications/update-status /.netlify/functions/admin-applications-update-status 200
+/api/admin/applications/verify-payment /.netlify/functions/admin-applications-verify-payment 200
 /api/analytics/metrics /.netlify/functions/analytics-metrics 200
 /api/analytics/telemetry /.netlify/functions/analytics-telemetry 200
 /api/analytics/predictive-dashboard /.netlify/functions/analytics-predictive-dashboard 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -40,6 +40,18 @@
   force = true
 
 [[redirects]]
+  from = "/api/admin/applications/update-status"
+  to = "/.netlify/functions/admin-applications-update-status"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/api/admin/applications/verify-payment"
+  to = "/.netlify/functions/admin-applications-verify-payment"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/api/analytics/telemetry"
   to = "/.netlify/functions/analytics-telemetry"
   status = 200

--- a/netlify/functions/admin-applications-update-status.js
+++ b/netlify/functions/admin-applications-update-status.js
@@ -1,0 +1,64 @@
+const handler = require('../../api/admin/applications/update-status.js')
+
+exports.handler = async (event, context) => {
+  let body = event.body
+  if (typeof body === 'string') {
+    try {
+      body = JSON.parse(body)
+    } catch (e) {
+      body = {}
+    }
+  }
+
+  const req = {
+    method: event.httpMethod,
+    query: event.queryStringParameters || {},
+    body: body,
+    headers: event.headers,
+    params: event.pathParameters || {}
+  }
+
+  const res = {
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization'
+    },
+    setHeader: function(name, value) { this.headers[name] = value },
+    status: function(code) { this.statusCode = code; return this },
+    json: function(data) { this.body = JSON.stringify(data); return this },
+    end: function(data) { this.body = data || ''; return this }
+  }
+
+  // Handle OPTIONS preflight
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 200,
+      headers: res.headers,
+      body: ''
+    }
+  }
+
+  try {
+    if (typeof handler === 'function') {
+      await handler(req, res)
+    } else if (handler.handler) {
+      await handler.handler(req, res)
+    } else if (handler.default) {
+      await handler.default(req, res)
+    } else {
+      await handler(req, res)
+    }
+  } catch (error) {
+    console.error('admin-applications-update-status error:', error)
+    res.status(500).json({ error: 'Internal server error' })
+  }
+
+  return {
+    statusCode: res.statusCode,
+    headers: res.headers,
+    body: res.body || JSON.stringify({ error: 'No response' })
+  }
+}

--- a/netlify/functions/admin-applications-verify-payment.js
+++ b/netlify/functions/admin-applications-verify-payment.js
@@ -1,0 +1,64 @@
+const handler = require('../../api/admin/applications/verify-payment.js')
+
+exports.handler = async (event, context) => {
+  let body = event.body
+  if (typeof body === 'string') {
+    try {
+      body = JSON.parse(body)
+    } catch (e) {
+      body = {}
+    }
+  }
+
+  const req = {
+    method: event.httpMethod,
+    query: event.queryStringParameters || {},
+    body: body,
+    headers: event.headers,
+    params: event.pathParameters || {}
+  }
+
+  const res = {
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization'
+    },
+    setHeader: function(name, value) { this.headers[name] = value },
+    status: function(code) { this.statusCode = code; return this },
+    json: function(data) { this.body = JSON.stringify(data); return this },
+    end: function(data) { this.body = data || ''; return this }
+  }
+
+  // Handle OPTIONS preflight
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 200,
+      headers: res.headers,
+      body: ''
+    }
+  }
+
+  try {
+    if (typeof handler === 'function') {
+      await handler(req, res)
+    } else if (handler.handler) {
+      await handler.handler(req, res)
+    } else if (handler.default) {
+      await handler.default(req, res)
+    } else {
+      await handler(req, res)
+    }
+  } catch (error) {
+    console.error('admin-applications-verify-payment error:', error)
+    res.status(500).json({ error: 'Internal server error' })
+  }
+
+  return {
+    statusCode: res.statusCode,
+    headers: res.headers,
+    body: res.body || JSON.stringify({ error: 'No response' })
+  }
+}


### PR DESCRIPTION
## Summary
- add Netlify function wrappers for the admin application update-status and verify-payment handlers with JSON parsing and CORS handling
- register the new functions in both `_redirects` and `netlify.toml` so the `/api/admin/applications/*` routes resolve correctly

## Testing
- `npx --yes netlify-cli@17.34.1 dev --no-open --port 9999`
- `curl -i -X POST http://localhost:9999/api/admin/applications/update-status -H 'Content-Type: application/json' -d '{"applicationId":"123","status":"approved"}'`
- `curl -i -X POST http://localhost:9999/api/admin/applications/verify-payment -H 'Content-Type: application/json' -d '{"applicationId":"123","paymentStatus":"verified"}'`


------
https://chatgpt.com/codex/tasks/task_e_68d2423353a883328f91f2dafd5093e1